### PR TITLE
error in prod:

### DIFF
--- a/src/AppBundle/Twig/AppExtension.php
+++ b/src/AppBundle/Twig/AppExtension.php
@@ -243,8 +243,13 @@ class AppExtension extends AbstractExtension implements GlobalsInterface
 
     public function moneyFilter($value)
     {
-        return \NumberFormatter::create("nl_NL",\NumberFormatter::CURRENCY)
-            ->formatCurrency((float)$value,"EUR");
+        // check if locale set in %framework.default_locale% is supported
+        if (setlocale(LC_ALL, 0) && 'C' !== setlocale(LC_ALL, 0)) {
+            return money_format('%+#1n', (float) $value);
+        }
+
+        // or fallback
+        return '€ '.number_format((float) $value, 2, ',', '.');
     }
 
     /**


### PR DESCRIPTION
An exception has been thrown during the rendering of a template (\"The Symfony\\Component\\Intl\\NumberFormatter\\NumberFormatter::__construct() method's argument $locale value 'nl_NL' behavior is not implemented. Only the locale \"en\" is supported.  Please install the \"intl\" extension for full localization capabilities.\"). at /data/www/ecd.deregenboog.org/releases/20221216165452Z/src/HsBundle/Resources/views/klanten/index.html.twig:76, Symfony\\Component\\Intl\\Exception\\MethodArgumentValueNotImplementedException(code: 0): The Symfony\\Component\\Intl\\NumberFormatter\\NumberFormatter::__construct() method's argument $locale value 'nl_NL' behavior is not implemented. Only the locale \"en\" is supported.  Please install the \"intl\" extension for full localization capabilities.