### PR TITLE
Fix foutmeldingen bij ontdubbelen

### DIFF
--- a/src/AppBundle/Controller/Admin/KlantenController.php
+++ b/src/AppBundle/Controller/Admin/KlantenController.php
@@ -10,6 +10,7 @@ use AppBundle\Service\KlantDao;
 use AppBundle\Service\KlantDaoInterface;
 use Doctrine\ORM\EntityManager;
 use JMS\DiExtraBundle\Annotation as DI;
+use Monolog\Logger;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
@@ -32,13 +33,15 @@ class KlantenController extends AbstractController
     protected $dao;
 
     /**
-     * @param KlantDao $dao
+     * @var LoggerInterface
      */
-    public function __construct(KlantDao $dao)
+    protected $logger;
+
+    public function __construct(KlantDao $dao, LoggerInterface $logger)
     {
         $this->dao = $dao;
+        $this->logger = $logger;
     }
-
 
     /**
      * @Route("/duplicates/{mode}")
@@ -89,24 +92,12 @@ class KlantenController extends AbstractController
             $em->beginTransaction();
             try {
                 $selected = $form->get('klanten')->getData();
-                $logger = $this->getLogger('merge');
                 $this->dao->create($entity);
-                $this->moveAssociations($entity, $selected, $em, $logger);
-                $this->disableMerged($entity, $selected, $em, $logger);
+                $this->moveAssociations($entity, $selected, $em);
+                $this->disableMerged($entity, $selected, $em);
                 $em->commit();
 
-                // reload entity and update calculated fields
-                $em->clear();
-                $entity = $this->dao->find($entity->getId());
-                $entity->updateCalculatedFields();
-                $this->dao->update($entity);
-
                 $this->addFlash('success', 'De dossiers zijn samengevoegd.');
-            } catch(UserException $e) {
-//                $this->logger->error($e->getMessage(), ['exception' => $e]);
-                $message =  $e->getMessage();
-                $this->addFlash('danger', $message);
-                return $this->redirectToRoute('app_klanten_index');
             }  catch (\Exception $e) {
                 $em->rollback();
 
@@ -114,8 +105,14 @@ class KlantenController extends AbstractController
                 $message = $this->getParameter('kernel.debug') ? $e->getMessage() : 'Er is een fout opgetreden.';
                 $this->addFlash('danger', $message);
 
-                return $this->redirectToRoute('app_klanten_index');
+                return $this->redirectToRoute('app_admin_klanten_duplicates');
             }
+
+            // reload entity and update calculated fields
+            $em->clear();
+            $entity = $this->dao->find($entity->getId());
+            $entity->updateCalculatedFields();
+            $this->dao->update($entity);
 
             return $this->redirectToRoute('app_klanten_view', ['id' => $entity->getId()]);
         }
@@ -130,9 +127,8 @@ class KlantenController extends AbstractController
      * @param Klant           $entity  new entity
      * @param Klant[]         $klanten original entities
      * @param EntityManager   $em
-     * @param LoggerInterface $logger
      */
-    private function moveAssociations($entity, $klanten, EntityManager $em, LoggerInterface $logger)
+    private function moveAssociations($entity, $klanten, EntityManager $em)
     {
         $dqls = [];
         $allMetadata = $em->getMetadataFactory()->getAllMetadata();
@@ -159,28 +155,27 @@ class KlantenController extends AbstractController
             'new' => $entity->getId(),
             'old' => array_map(function ($klant) { return $klant->getId(); }, $klanten),
         ];
-        $logger->debug('Start moving associations', $context);
+        $this->logger->debug('Start moving associations', $context);
 
         foreach ($dqls as $dql) {
             $count = $em->createQuery($dql)->execute();
-            $logger->debug($dql, ['count' => $count]);
+            $this->logger->debug($dql, ['count' => $count]);
         }
 
-        $logger->debug('Finished moving associations', $context);
+        $this->logger->debug('Finished moving associations', $context);
     }
 
     /**
      * @param Klant           $entity  new entity
      * @param Klant[]         $klanten
      * @param EntityManager   $em
-     * @param LoggerInterface $logger
      */
-    private function disableMerged($entity, $klanten, EntityManager $em, LoggerInterface $logger)
+    private function disableMerged($entity, $klanten, EntityManager $em)
     {
         foreach ($klanten as $klant) {
             $klant->setMerged($entity);
             $context = ['id' => $klant->getId(), 'merged_id' => $entity->getId()];
-            $logger->debug('Disabling merged', $context);
+            $this->logger->debug('Disabling merged', $context);
         }
 
         $em->flush();

--- a/src/AppBundle/Entity/Klant.php
+++ b/src/AppBundle/Entity/Klant.php
@@ -45,7 +45,7 @@ class Klant extends Persoon
     private $mezzoId = 0;
 
     /**
-     * @var Intake[]
+     * @var ArrayCollection<Intake>
      *
      * @ORM\OneToMany(targetEntity="InloopBundle\Entity\Intake", mappedBy="klant")
      * @ORM\OrderBy({"intakedatum" = "DESC", "id" = "DESC"})
@@ -69,7 +69,7 @@ class Klant extends Persoon
     private $verslagen;
 
     /**
-     * @var Registratie[]
+     * @var ArrayCollection<Registratie>
      *
      * @ORM\OneToMany(targetEntity="InloopBundle\Entity\Registratie", mappedBy="klant")
      * @ORM\OrderBy({"id" = "DESC"})
@@ -593,28 +593,28 @@ class Klant extends Persoon
         $this->eersteIntake = $eersteIntake;
     }
 
-
-    /**
-     * Wat doet deze functie? Geen idee.
-     * Hij is erg verwarrend...
-     *
-     * Hij wordt alleen gebruikt bij mergen van klanten. en dan kan het zijn dat ie werkt, mara verder is
-     * hij stom want hij doet niet wat ie moet doen.
-     *
-     * Let op bij merge nagaan of dit allemaal nog goed gaat.
-     *
-     * @return void
-     */
     public function updateCalculatedFields()
     {
-        if (count((array) $this->registraties) > 0) {
-            $this->laatsteRegistratie = $this->registraties->last();
+        $laatsteRegistratie = null;
+        foreach ($this->registraties as $registratie) {
+            if ($laatsteRegistratie == null || $registratie->getBinnen() > $laatsteRegistratie->getBinnen()) {
+                $laatsteRegistratie = $registratie;
+            }
         }
-        if (count((array) $this->intakes) > 0) {
-            $this->laatsteIntake = $this->intakes->last();
-            $eersteIntake = $this->intakes->first();
-            $this->eersteIntakeDatum = $eersteIntake->getIntakeDatum();
+        $this->laatsteRegistratie = $laatsteRegistratie;
+
+        $eersteIntake = null;
+        $laatsteIntake = null;
+        foreach ($this->intakes as $intake) {
+            if ($eersteIntake == null || $intake->getIntakedatum() < $eersteIntake->getIntakedatum()) {
+                $eersteIntake = $intake;
+            }
+            if ($laatsteIntake == null || $intake->getIntakedatum() > $laatsteIntake->getIntakedatum()) {
+                $laatsteIntake = $intake;
+            }
         }
+        $this->laatsteIntake = $laatsteIntake;
+        $this->eersteIntakeDatum = $eersteIntake->getIntakeDatum();
     }
 
     public function isOverleden()

--- a/src/AppBundle/Resources/config/services.yml
+++ b/src/AppBundle/Resources/config/services.yml
@@ -21,6 +21,11 @@ services:
             $paginator: '@knp_paginator'
         tags: [ 'controller.service_arguments' ]
 
+    AppBundle\Controller\Admin\KlantenController:
+        arguments:
+            $logger: '@monolog.logger.merge'
+        tags: [ 'controller.service_arguments' ]
+
     AppBundle\Controller\KlantenController:
         arguments:
              $export: '@AppBundle\Export\Klanten'

--- a/src/AppBundle/Twig/AppExtension.php
+++ b/src/AppBundle/Twig/AppExtension.php
@@ -9,7 +9,6 @@ use AppBundle\Service\NameFormatter;
 use AppBundle\Util\DateTimeUtil;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\EntityNotFoundException;
-use Symfony\Component\Debug\Exception\ContextErrorException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\TwigFunction;
@@ -17,6 +16,7 @@ use Twig\TwigFilter;
 use Twig\Extension\AbstractExtension;
 use Twig\Extension\GlobalsInterface;
 use Twig\Environment;
+use Twig\Error\Error;
 
 class AppExtension extends AbstractExtension implements GlobalsInterface
 {
@@ -486,12 +486,15 @@ class AppExtension extends AbstractExtension implements GlobalsInterface
     public function try($value)
     {
         try {
-            if (is_bool($value)) {
-                return (string) $value ? 1 : 0;
+            switch (true) {
+                case is_bool($value):
+                    return (string) $value ? 1 : 0;
+                case $value instanceof \DateTime:
+                    return $value->format('d-m-Y');
+                default:
+                    return (string) $value;
             }
-
-            return (string) $value;
-        } catch (ContextErrorException $e) {
+        } catch (Error $e) {
             return '';
         }
     }

--- a/src/MwBundle/Entity/BinnenViaOptieKlant.php
+++ b/src/MwBundle/Entity/BinnenViaOptieKlant.php
@@ -2,11 +2,6 @@
 
 namespace MwBundle\Entity;
 
-use AppBundle\Entity\Klant;
-use AppBundle\Model\ActivatableTrait;
-use AppBundle\Model\IdentifiableTrait;
-use AppBundle\Model\NameableTrait;
-use AppBundle\Model\TimestampableTrait;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 
@@ -17,17 +12,4 @@ use Gedmo\Mapping\Annotation as Gedmo;
  */
 class BinnenViaOptieKlant extends BinnenVia
 {
-    /**
-     * @var Aanmelding[] $aanmeldingen
-     * @ORM\OneToMany(targetEntity="MwBundle\Entity\Aanmelding", mappedBy="binnenViaOptieKlant" )
-     */
-    protected $aanmeldingen;
-
-    /**
-     * @var Klant
-     * @ORM\OneToMany(targetEntity="AppBundle\Entity\Klant", mappedBy="mwBinnenViaOptieKlant")
-     */
-    protected $klant;
-
-
 }


### PR DESCRIPTION
Closes #1277 

Foutmeldingen bij ontdubbelen zijn weggewerkt, voor alle strategieen. Ik heb niet inhoudelijk gecheckt of het samenvoegen van alle diensten ook foutloos verloopt. Functioneel zou het nu zo moeten werken als het voorheen deed voordat het stuk ging.