### PR TITLE
Specify full class name to ParamConverter

### DIFF
--- a/src/AppBundle/Controller/KlantenController.php
+++ b/src/AppBundle/Controller/KlantenController.php
@@ -171,8 +171,7 @@ class KlantenController extends AbstractController
 
     /**
      * @Route("/{klant}/addPartner")
-     * ParamConverter("klant",class="AppBundle:Klant")
-     *
+     * ParamConverter("klant", class="AppBundle\Entity\Klant")
      */
     public function addPartnerAction(Request $request, $klant)
     {

--- a/src/InloopBundle/Controller/IncidentenController.php
+++ b/src/InloopBundle/Controller/IncidentenController.php
@@ -61,7 +61,7 @@ class IncidentenController extends AbstractChildController
 
     /**
      * @Route("/addPrefilled/locatie/{locatie}")
-     * @ParamConverter("locatie", class="InloopBundle:Locatie")
+     * @ParamConverter("locatie", class="InloopBundle\Entity\Locatie")
      * @Template("inloop/incidenten/add.html.twig")
      */
     public function addPrefilledAction(Request $request, Locatie $locatie)

--- a/src/InloopBundle/Controller/IntakesController.php
+++ b/src/InloopBundle/Controller/IntakesController.php
@@ -83,7 +83,7 @@ class IntakesController extends AbstractController
 
     /**
      * @Route("/add/{klant}")
-     * @ParamConverter("klant", class="AppBundle:Klant")
+     * @ParamConverter("klant", class="AppBundle\Entity\Klant")
      */
     public function addAction(Request $request)
     {

--- a/src/InloopBundle/Controller/KlantenController.php
+++ b/src/InloopBundle/Controller/KlantenController.php
@@ -106,7 +106,7 @@ class KlantenController extends AbstractController
 
     /**
      * @Route("/{klant}/rapportage")
-     * @ParamConverter("klant", class="AppBundle:Klant")
+     * @ParamConverter("klant", class="AppBundle\Entity\Klant")
      */
     public function viewReport(Request $request, Klant $klant)
     {
@@ -215,7 +215,7 @@ class KlantenController extends AbstractController
 
     /**
      * @Route("/{klant}/amoc.pdf")
-     * @ParamConverter("klant", class="AppBundle:Klant")
+     * @ParamConverter("klant", class="AppBundle\Entity\Klant")
      */
     public function amocAction(Klant $klant)
     {

--- a/src/InloopBundle/Controller/OpmerkingenController.php
+++ b/src/InloopBundle/Controller/OpmerkingenController.php
@@ -45,8 +45,8 @@ class OpmerkingenController extends AbstractController
     /**
      * @Route("/{klant}", requirements={"klant"="\d+"}, defaults={"locatie" = null})
      * @Route("/{klant}/{locatie}", requirements={"klant"="\d+", "locatie"="\d+"})
-     * @ParamConverter("klant", class="AppBundle:Klant")
-     * @ParamConverter("locatie", class="InloopBundle:Locatie")
+     * @ParamConverter("klant", class="AppBundle\Entity\Klant")
+     * @ParamConverter("locatie", class="InloopBundle\Entity\Locatie")
      */
     public function indexAction(Request $request)
     {
@@ -69,7 +69,7 @@ class OpmerkingenController extends AbstractController
 
     /**
      * @Route("/add/{klant}")
-     * @ParamConverter("klant", class="AppBundle:Klant")
+     * @ParamConverter("klant", class="AppBundle\Entity\Klant")
      */
     public function addAction(Request $request)
     {
@@ -81,7 +81,7 @@ class OpmerkingenController extends AbstractController
 
     /**
      * @Route("/{opmerking}/delete", methods={"POST"})
-     * @ParamConverter("opmerking", class="AppBundle:Opmerking")
+     * @ParamConverter("opmerking", class="AppBundle\Entity\Opmerking")
      */
     public function deleteAction(Request $request, $opmerking)
     {

--- a/src/InloopBundle/Controller/RegistratiesController.php
+++ b/src/InloopBundle/Controller/RegistratiesController.php
@@ -139,8 +139,8 @@ class RegistratiesController extends AbstractController
 
     /**
      * @Route("/klanten/{locatieType}/{locatie}", name="inloop_registraties_klanten", requirements={"locatie" = "\d+", "locatieType"="\S+"})
-     * @ParamConverter("locatie", class="InloopBundle:Locatie")
-     * @ParamConverter("locatieType",class="InloopBundle:LocatieType",options={"mapping": {"locatieType"="naam"}})
+     * @ParamConverter("locatie", class="InloopBundle\Entity\Locatie")
+     * @ParamConverter("locatieType",class="InloopBundle\Entity\LocatieType",options={"mapping": {"locatieType"="naam"}})
      */
     public function klantenAction(Request $request)
     {
@@ -189,8 +189,8 @@ class RegistratiesController extends AbstractController
      * Route("/active/{locatie}")
      *
      * @Route("/active/{locatieType}/{locatie}", name="inloop_registraties_active", requirements={"locatie" = "\d+", "locatieType"="\S+"})
-     * @ParamConverter("locatie", class="InloopBundle:Locatie")
-     * @ParamConverter("locatieType",class="InloopBundle:LocatieType",options={"mapping": {"locatieType"="naam"}})
+     * @ParamConverter("locatie", class="InloopBundle\Entity\Locatie")
+     * @ParamConverter("locatieType",class="InloopBundle\Entity\LocatieType",options={"mapping": {"locatieType"="naam"}})
      */
     public function activeAction(Request $request, Locatie $locatie)
     {
@@ -235,8 +235,8 @@ class RegistratiesController extends AbstractController
      * Route("/history/{locatie}")
      *
      * @Route("/history/{locatieType}/{locatie}", name="inloop_registraties_history", requirements={"locatie" = "\d+", "locatieType"="\S+"})
-     * @ParamConverter("locatie", class="InloopBundle:Locatie")
-     * @ParamConverter("locatieType",class="InloopBundle:LocatieType",options={"mapping": {"locatieType"="naam"}})
+     * @ParamConverter("locatie", class="InloopBundle\Entity\Locatie")
+     * @ParamConverter("locatieType",class="InloopBundle\Entity\LocatieType",options={"mapping": {"locatieType"="naam"}})
      */
     public function historyAction(Request $request, Locatie $locatie)
     {
@@ -520,7 +520,7 @@ class RegistratiesController extends AbstractController
 
     /**
      * @Route("/{registratie}/delete")
-     * @ParamConverter("registratie", class="InloopBundle:Registratie")
+     * @ParamConverter("registratie", class="InloopBundle\Entity\Registratie")
      */
     public function deleteAction(Request $request, $registratie)
     {

--- a/src/InloopBundle/Controller/SchorsingenController.php
+++ b/src/InloopBundle/Controller/SchorsingenController.php
@@ -146,7 +146,7 @@ class SchorsingenController extends AbstractController
 
     /**
      * @Route("/add/{klant}")
-     * @ParamConverter("klant", class="AppBundle:Klant")
+     * @ParamConverter("klant", class="AppBundle\Entity\Klant")
      */
     public function addAction(Request $request)
     {

--- a/src/InloopBundle/Controller/VerslagenController.php
+++ b/src/InloopBundle/Controller/VerslagenController.php
@@ -58,7 +58,7 @@ class VerslagenController extends AbstractController
 
     /**
      * @Route("/add/{klant}")
-     * @ParamConverter("klant", class="AppBundle:Klant")
+     * @ParamConverter("klant", class="AppBundle\Entity\Klant")
      */
     public function addAction(Request $request)
     {

--- a/src/MwBundle/Controller/VerslagenController.php
+++ b/src/MwBundle/Controller/VerslagenController.php
@@ -77,7 +77,7 @@ class VerslagenController extends AbstractController
 
     /**
      * @Route("/add/{klant}")
-     * @ParamConverter("klant", class="AppBundle:Klant")
+     * @ParamConverter("klant", class="AppBundle\Entity\Klant")
      */
     public function addAction(Request $request)
     {

--- a/src/OekraineBundle/Controller/BezoekersController.php
+++ b/src/OekraineBundle/Controller/BezoekersController.php
@@ -147,7 +147,7 @@ class BezoekersController extends AbstractController
 
     /**
      * @Route("/{klant}/rapportage")
-     * @ParamConverter("klant", class="OekraineBundle:Bezoeker")
+     * @ParamConverter("klant", class="OekraineBundle\Entity\Bezoeker")
      */
     public function viewReport(Request $request, Bezoeker $bezoeker)
     {

--- a/src/OekraineBundle/Controller/IncidentenController.php
+++ b/src/OekraineBundle/Controller/IncidentenController.php
@@ -60,7 +60,7 @@ class IncidentenController extends AbstractChildController
 
     /**
      * @Route("/addPrefilled/locatie/{locatie}")
-     * @ParamConverter("locatie", class="OekraineBundle:Locatie")
+     * @ParamConverter("locatie", class="OekraineBundle\Entity\Locatie")
      * @Template("oekraine/incidenten/add.html.twig")
      */
     public function addPrefilledAction(Request $request, Locatie $locatie)

--- a/src/OekraineBundle/Controller/IntakesController.php
+++ b/src/OekraineBundle/Controller/IntakesController.php
@@ -65,7 +65,7 @@ class IntakesController extends AbstractController
 
     /**
      * @Route("/add/{bezoeker}")
-     * @ParamConverter("bezoeker", class="OekraineBundle:Bezoeker")
+     * @ParamConverter("bezoeker", class="OekraineBundle\Entity\Bezoeker")
      */
     public function addAction(Request $request)
     {

--- a/src/OekraineBundle/Controller/OpmerkingenController.php
+++ b/src/OekraineBundle/Controller/OpmerkingenController.php
@@ -45,8 +45,8 @@ class OpmerkingenController extends AbstractController
     /**
      * @Route("/{klant}", requirements={"klant"="\d+"}, defaults={"locatie" = null})
      * @Route("/{klant}/{locatie}", requirements={"klant"="\d+", "locatie"="\d+"})
-     * @ParamConverter("klant", class="AppBundle:Klant")
-     * @ParamConverter("locatie", class="OekraineBundle:Locatie")
+     * @ParamConverter("klant", class="AppBundle\Entity\Klant")
+     * @ParamConverter("locatie", class="OekraineBundle\Entity\Locatie")
      */
     public function indexAction(Request $request)
     {
@@ -69,7 +69,7 @@ class OpmerkingenController extends AbstractController
 
     /**
      * @Route("/add/{klant}")
-     * @ParamConverter("klant", class="AppBundle:Klant")
+     * @ParamConverter("klant", class="AppBundle\Entity\Klant")
      */
     public function addAction(Request $request)
     {
@@ -81,7 +81,7 @@ class OpmerkingenController extends AbstractController
 
     /**
      * @Route("/{opmerking}/delete", methods={"POST"})
-     * @ParamConverter("opmerking", class="AppBundle:Opmerking")
+     * @ParamConverter("opmerking", class="AppBundle\Entity\Opmerking")
      */
     public function deleteAction(Request $request, $opmerking)
     {

--- a/src/OekraineBundle/Controller/RegistratiesController.php
+++ b/src/OekraineBundle/Controller/RegistratiesController.php
@@ -101,7 +101,7 @@ class RegistratiesController extends AbstractController
 
     /**
      * @Route("/{locatie}", requirements={"locatie" = "\d+"})
-     * @ParamConverter("locatie", class="OekraineBundle:Locatie")
+     * @ParamConverter("locatie", class="OekraineBundle\Entity\Locatie")
      */
     public function indexAction(Request $request)
     {
@@ -341,7 +341,7 @@ class RegistratiesController extends AbstractController
 
     /**
      * @Route("/{registratie}/delete")
-     * @ParamConverter("registratie", class="OekraineBundle:Registratie")
+     * @ParamConverter("registratie", class="OekraineBundle\Entity\Registratie")
      */
     public function deleteAction(Request $request, $registratie)
     {

--- a/src/VillaBundle/Controller/VerslagenController.php
+++ b/src/VillaBundle/Controller/VerslagenController.php
@@ -66,7 +66,7 @@ class VerslagenController extends AbstractController
 
     /**
      * @Route("/add/{klant}")
-     * @ParamConverter("klant", class="AppBundle:Klant")
+     * @ParamConverter("klant", class="AppBundle\Entity\Klant")
      */
     public function addAction(Request $request)
     {


### PR DESCRIPTION
@jtborger Nu we geen bundles meer gebruiken kent Doctrine de namespace alias niet meer, dus moeten we de hele class name gebruiken bij property `class` van `ParamConverter`. Belangrijk om deze te mergen voordat je een nieuwe release doet.