### PR TITLE
Add DAO maker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -79,6 +79,7 @@
         "symfony/monolog-bundle": "^3.1",
         "symfony/runtime": "5.4.*",
         "symfony/security-bundle": "5.4.*",
+        "symfony/string": "5.4.*",
         "symfony/twig-bundle": "5.4.*",
         "symfony/validator": "5.4.*",
         "symfony/webpack-encore-bundle": "^1.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d462841fb79c7a678a34981eebef1797",
+    "content-hash": "4a0e15fa8f34ce47a9fb1ecb50cabb05",
     "packages": [
         {
             "name": "backup-manager/backup-manager",
@@ -7928,16 +7928,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v5.4.26",
+            "version": "v5.4.36",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "1181fe9270e373537475e826873b5867b863883c"
+                "reference": "4e232c83622bd8cd32b794216aa29d0d266d353b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/1181fe9270e373537475e826873b5867b863883c",
-                "reference": "1181fe9270e373537475e826873b5867b863883c",
+                "url": "https://api.github.com/repos/symfony/string/zipball/4e232c83622bd8cd32b794216aa29d0d266d353b",
+                "reference": "4e232c83622bd8cd32b794216aa29d0d266d353b",
                 "shasum": ""
             },
             "require": {
@@ -7994,7 +7994,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.4.26"
+                "source": "https://github.com/symfony/string/tree/v5.4.36"
             },
             "funding": [
                 {
@@ -8010,7 +8010,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-06-28T12:46:07+00:00"
+            "time": "2024-02-01T08:49:30+00:00"
         },
         {
             "name": "symfony/translation",

--- a/config/packages/dev/maker.yaml
+++ b/config/packages/dev/maker.yaml
@@ -1,0 +1,2 @@
+maker:
+  root_namespace: 'AppBundle'

--- a/config/services/app/services.yaml
+++ b/config/services/app/services.yaml
@@ -14,6 +14,10 @@ services:
     AppBundle\Command\:
         resource: '%kernel.project_dir%/src/AppBundle/Command'
 
+    # makers
+    AppBundle\Maker\:
+        resource: '%kernel.project_dir%/src/AppBundle/Maker'
+
     AppBundle\Command\DatabaseBackupCommand:
         arguments:
             $dsn: '%env(resolve:DATABASE_URL)%'

--- a/skeleton/dao/Dao.tpl.php
+++ b/skeleton/dao/Dao.tpl.php
@@ -1,0 +1,50 @@
+<?= "<?php\n" ?>
+
+namespace <?= $namespace ?>;
+
+<?= $use_statements; ?>
+
+class <?= $class_name ?> extends AbstractDao implements <?= $interface_name."\n" ?>
+{
+    protected $class = <?= $entity_class ?>::class;
+
+    protected $alias = '<?= $alias ?>';
+
+    protected $paginationOptions = [
+        'defaultSortFieldName' => $this->alias . '.id',
+        'defaultSortDirection' => 'asc',
+        'sortFieldWhitelist' => [
+            $this->alias . '.id',
+        ],
+    ];
+
+    public function findAll($page = null, FilterInterface $filter = null): ArrayCollection
+    {
+        $builder = $this->repository->createQueryBuilder($this->alias);
+
+        if ($filter) {
+            $filter->applyTo($builder);
+        }
+
+        if ($page) {
+            return $this->paginator->paginate($builder, $page, $this->itemsPerPage, $this->paginationOptions);
+        }
+
+        return $builder->getQuery()->getResult();
+    }
+
+    public function create(<?= $entity_class ?> $entity): void
+    {
+        $this->doCreate($entity);
+    }
+
+    public function update(<?= $entity_class ?> $entity): void
+    {
+        $this->doUpdate($entity);
+    }
+
+    public function delete(<?= $entity_class ?> $entity): void
+    {
+        $this->doDelete($entity);
+    }
+}

--- a/skeleton/dao/DaoInterface.tpl.php
+++ b/skeleton/dao/DaoInterface.tpl.php
@@ -1,0 +1,16 @@
+<?= "<?php\n" ?>
+
+namespace <?= $namespace ?>;
+
+<?= $use_statements; ?>
+
+interface <?= $class_name."\n" ?>
+{
+    public function find($id): <?= $entity_class ?>;
+
+    public function create(<?= $entity_class ?> $entity): void;
+
+    public function update(<?= $entity_class ?> $entity): void;
+
+    public function delete(<?= $entity_class ?> $entity): void;
+}

--- a/src/AppBundle/Maker/DaoMaker.php
+++ b/src/AppBundle/Maker/DaoMaker.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace AppBundle\Maker;
+
+use AppBundle\Filter\FilterInterface;
+use AppBundle\Service\AbstractDao;
+use Doctrine\Common\Collections\ArrayCollection;
+use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\DependencyBuilder;
+use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
+use Symfony\Bundle\MakerBundle\Generator;
+use Symfony\Bundle\MakerBundle\InputConfiguration;
+use Symfony\Bundle\MakerBundle\Maker\AbstractMaker;
+use Symfony\Bundle\MakerBundle\Str;
+use Symfony\Bundle\MakerBundle\Util\UseStatementGenerator;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\String\UnicodeString;
+
+final class DaoMaker extends AbstractMaker
+{
+    public static function getCommandName(): string
+    {
+        return 'make:dao';
+    }
+
+    public static function getCommandDescription(): string
+    {
+        return 'Create a new data access service for an entity';
+    }
+
+    public function configureCommand(Command $command, InputConfiguration $inputConfig): void
+    {
+        $command
+            ->addArgument('module', InputArgument::OPTIONAL, sprintf('Choose the module namespace for your data access service class (e.g. <fg=yellow>%sBundle</>)', Str::asClassName(Str::getRandomTerm())))
+            ->addArgument('entity', InputArgument::OPTIONAL, sprintf('Choose the entity for which you want to create the data access service (e.g. <fg=yellow>%s</>)', Str::asClassName(Str::getRandomTerm())))
+        ;
+    }
+
+    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
+    {
+        $module = $input->getArgument('module');
+        $entity = $input->getArgument('entity');
+        $alias = (new UnicodeString($entity))->snake()->toString();
+
+        $entityClassName = sprintf('\\%s\\Entity\\%s', $module, $entity);
+        $entityClassNameDetails = $generator->createClassNameDetails($entityClassName, '', '');
+        if (!class_exists($entityClassNameDetails->getFullName())) {
+            throw new RuntimeCommandException(sprintf('The entity %s does not exist.', $entityClassNameDetails->getFullName()));
+        }
+
+        $daoInterfaceName = sprintf('\\%s\\Service\\%sDaoInterface', $module, $entity);
+        $daoInterfaceNameDetails = $generator->createClassNameDetails($daoInterfaceName, '', '');
+
+        $daoClassName = sprintf('\\%s\\Service\\%sDao', $module, $entity);
+        $daoClassNameDetails = $generator->createClassNameDetails($daoClassName, '', '');
+
+        $generator->generateClass(
+            $daoInterfaceNameDetails->getFullName(),
+            'skeleton/dao/DaoInterface.tpl.php',
+            [
+                'use_statements' => new UseStatementGenerator([
+                    $entityClassNameDetails->getFullName(),
+                ]),
+                'entity_class' => $entityClassNameDetails->getShortName(),
+                'alias' => $alias,
+            ],
+        );
+        $generator->generateClass(
+            $daoClassNameDetails->getFullName(),
+            'skeleton/dao/Dao.tpl.php',
+            [
+                'use_statements' => new UseStatementGenerator([
+                    AbstractDao::class,
+                    $entityClassNameDetails->getFullName(),
+                    FilterInterface::class,
+                    ArrayCollection::class,
+                ]),
+                'interface_name' => $daoInterfaceNameDetails->getShortName(),
+                'entity_class' => $entityClassNameDetails->getShortName(),
+                'alias' => $alias,
+            ],
+        );
+        $generator->writeChanges();
+
+        $this->writeSuccessMessage($io);
+    }
+
+    public function configureDependencies(DependencyBuilder $dependencies): void
+    {
+    }
+}


### PR DESCRIPTION
Als "proof of concept" heb ik een DAO-maker toegevoegd. We kunnen dit uitbreiden naar andere services en wellicht ook naar een basis-module als geheel.

Gebruik: `bin/console make:dao <module> <entity>`

Bijvoorbeeld `bin/console make:dao AppBundle AmocLand` retulteert in een DAO-service en interface voor de betreffende entity.

```
<?php

namespace AppBundle\Service;

use AppBundle\Entity\AmocLand;

interface AmocLandDaoInterface
{
    public function find($id): AmocLand;
    public function create(AmocLand $entity): void;
    public function update(AmocLand $entity): void;
    public function delete(AmocLand $entity): void;
}
```

```
<?php

namespace AppBundle\Service;

use AppBundle\Entity\AmocLand;
use AppBundle\Service\AbstractDao;

class AmocLandDao extends AbstractDao implements AmocLandDaoInterface
{
    protected $class = AmocLand::class;

    protected $alias = 'amoc_land';

    public function find($id): AmocLand
    {
        return parent::find($id);
    }

    public function create(AmocLand $entity): void
    {
        $this->doCreate($entity);
    }

    public function update(AmocLand $entity): void
    {
        $this->doUpdate($entity);
    }

    public function delete(AmocLand $entity): void
    {
        $this->doDelete($entity);
    }
}
```
