### PR TITLE
Disable savepoints while running migrations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ docker-lint:
 docker-test-setup:
 	docker compose -f docker-compose.test.yml build --build-arg UID=$$(id -u) --build-arg GID=$$(id -g)
 	docker compose -f docker-compose.test.yml up --force-recreate --wait test-database && sleep 1
-	docker compose -f docker-compose.test.yml run --rm test bin/console -n doctrine:migrations:migrate
+	docker compose -f docker-compose.test.yml run --rm -e DOCTRINE_USE_SAVEPOINTS=false test bin/console -n doctrine:migrations:migrate
 	docker compose -f docker-compose.test.yml run --rm -e PREVENT_SAVE_ENABLED=false test bin/console -n hautelook:fixtures:load
 
 docker-test-run:

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -151,4 +151,4 @@ when@test:
         dbal:
             connections:
                 default:
-                    use_savepoints: true
+                    use_savepoints: '%env(bool:DOCTRINE_USE_SAVEPOINTS)%'

--- a/config/packages/parameters.yaml
+++ b/config/packages/parameters.yaml
@@ -121,3 +121,7 @@ parameters:
 #     - TwBundle\Entity\Klant
 #     - AppBundle\Entity\Toestemmingsformulier
 
+when@test:
+  parameters:
+    # default values for env vars (in case not defined)
+    env(DOCTRINE_USE_SAVEPOINTS): 'true'


### PR DESCRIPTION
Ik heb de MySQL-savepoints in `test` env standaard aangezet, maar bij het draaien van de migraties wordt hij uitgezet dmv de env var `DOCTRINE_USE_SAVEPOINTS`. Voor mij werkt dit zo.