### PR TITLE
Ignore when no closing time #1715

### DIFF
--- a/src/InloopBundle/Command/UnregisterAllCommand.php
+++ b/src/InloopBundle/Command/UnregisterAllCommand.php
@@ -18,6 +18,7 @@ class UnregisterAllCommand extends \Symfony\Component\Console\Command\Command
      * @var RegistratieDaoInterface
      */
     private $registratieDao;
+
     public function __construct(\InloopBundle\Service\RegistratieDao $registratieDao)
     {
         $this->registratieDao = $registratieDao;
@@ -32,7 +33,6 @@ class UnregisterAllCommand extends \Symfony\Component\Console\Command\Command
     protected function initialize(InputInterface $input, OutputInterface $output)
     {
         $this->now = new \DateTime();
-        $this->registratieDao = $this->registratieDao;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -71,6 +71,12 @@ class UnregisterAllCommand extends \Symfony\Component\Console\Command\Command
             }
 
             $closingTime = $closingTimes[$locationId][$dayOfWeek];
+
+            // ignore if there is no closing time for this day
+            if (!$closingTime) {
+                continue;
+            }
+
             $buiten = DateTimeUtil::combine($registration->getBinnen(), $closingTime);
 
             // ignore if location is still open

--- a/src/InloopBundle/Entity/Locatie.php
+++ b/src/InloopBundle/Entity/Locatie.php
@@ -336,17 +336,16 @@ class Locatie
             return false;
 
         }
-
-
     }
 
-    public function getClosingTimeByDayOfWeek($dayOfWeek)
+    public function getClosingTimeByDayOfWeek(int $dayOfWeek): ?\DateTime
     {
         foreach ($this->locatietijden as $locatietijd) {
             if ($dayOfWeek == $locatietijd->getDagVanDeWeek()) {
                 return $locatietijd->getSluitingstijd();
             }
         }
+        return null;
     }
 
     public function isDeletable()


### PR DESCRIPTION
Error treedt op als er geen sluitingstijd is voor de betreffende dag van de week. Deze PR zorgt ervoor dat de error verdwijnt, maar ik weet niet zeker of dit de gewenste oplossing is.

Als iemand nu ingecheckt is en unregisterAll wordt gedraaid en er is geen sluitingstijd voor die dag, betekent dit wellicht dat het "nu" na middernacht is en dus gekeken moet worden naar de sluitingstijd van de dag ervoor. @jtborger Hoor graag jouw ideeën hierover.

Fixes #1715 