### PR TITLE
Onderscheid maken afsluitingen deelnemers/vrijwilligers #1160

### DIFF
--- a/migrations/2024/Version20240417104410.php
+++ b/migrations/2024/Version20240417104410.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240417104410 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Doelgroepen toevoegen aan afsluitingen';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE iz_afsluitingen ADD doelgroepen INT DEFAULT 3');
+        $this->addSql('ALTER TABLE iz_afsluitingen MODIFY COLUMN doelgroepen INT NOT NULL;');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE iz_afsluitingen DROP doelgroepen');
+    }
+}

--- a/src/IzBundle/Controller/KlantenController.php
+++ b/src/IzBundle/Controller/KlantenController.php
@@ -110,7 +110,7 @@ class KlantenController extends AbstractController
      */
     public function reopenAction(Request $request, $id)
     {
-        $this->getDoctrine()->getManager()->getFilters()->disable("foutieve_invoer");
+        $this->getEntityManager()->getFilters()->disable("foutieve_invoer");
         $entity = $this->dao->find($id);
 
         $form = $this->getForm(ConfirmationType::class);

--- a/src/IzBundle/Entity/Afsluiting.php
+++ b/src/IzBundle/Entity/Afsluiting.php
@@ -17,6 +17,13 @@ use Gedmo\Mapping\Annotation as Gedmo;
  */
 class Afsluiting
 {
+    const DOELGROEP_KLANT = 1;
+    const DOELGROEP_VRIJWILLIGER = 2;
+    const DOELGROEPEN_LABELS = [
+        self::DOELGROEP_KLANT => 'Deelnemers',
+        self::DOELGROEP_VRIJWILLIGER => 'Vrijwilligers',
+    ];
+
     use IdentifiableTrait;
     use NameableTrait;
     use ActivatableTrait;
@@ -51,4 +58,32 @@ class Afsluiting
      * @Gedmo\Versioned
      */
     protected $modified;
+
+    /**
+     * @ORM\Column(type="integer", nullable=false)
+     * @Gedmo\Versioned
+     */
+    protected $doelgroepen = self::DOELGROEP_KLANT + self::DOELGROEP_VRIJWILLIGER;
+
+    public function getDoelgroepen(): array
+    {
+        $doelgroep = [];
+        foreach (array_keys(self::DOELGROEPEN_LABELS) as $bit) {
+            if ($this->doelgroepen & $bit) {
+                $doelgroep[] = $bit;
+            }
+        }
+
+        return $doelgroep;
+    }
+
+    public function setDoelgroepen(array $doelgroepen): self
+    {
+        $this->doelgroepen = 0;
+        foreach ($doelgroepen as $doelgroep) {
+            $this->doelgroepen += $doelgroep;
+        }
+
+        return $this;
+    }
 }

--- a/src/IzBundle/Form/AfsluitingSelectType.php
+++ b/src/IzBundle/Form/AfsluitingSelectType.php
@@ -3,8 +3,10 @@
 namespace IzBundle\Form;
 
 use AppBundle\Form\BaseSelectType;
+use Doctrine\ORM\EntityRepository;
 use IzBundle\Entity\Afsluiting;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class AfsluitingSelectType extends AbstractType
@@ -14,9 +16,20 @@ class AfsluitingSelectType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
+        $resolver->setRequired(['doelgroepen']);
+
         $resolver->setDefaults([
             'label' => 'Afsluitreden',
             'class' => Afsluiting::class,
+            'query_builder' => function (Options $options) {
+                return function (EntityRepository $repo) use ($options) {
+                    return $repo->createQueryBuilder('afsluiting')
+                        ->where('bit_and(afsluiting.doelgroepen, :doelgroepen) <> 0')
+                        ->setParameter('doelgroepen', $options['doelgroepen'])
+                        ->orderBy('afsluiting.naam')
+                    ;
+                };
+            },
         ]);
     }
 

--- a/src/IzBundle/Form/AfsluitingType.php
+++ b/src/IzBundle/Form/AfsluitingType.php
@@ -5,6 +5,7 @@ namespace IzBundle\Form;
 use AppBundle\Form\BaseType;
 use IzBundle\Entity\Afsluiting;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -18,6 +19,11 @@ class AfsluitingType extends AbstractType
     {
         $builder
             ->add('naam')
+            ->add('doelgroepen', ChoiceType::class, [
+                'choices' => array_flip(Afsluiting::DOELGROEPEN_LABELS),
+                'multiple' => true,
+                'by_reference' => false,
+            ])
             ->add('actief')
             ->add('submit', SubmitType::class)
         ;

--- a/src/IzBundle/Form/IzDeelnemerCloseType.php
+++ b/src/IzBundle/Form/IzDeelnemerCloseType.php
@@ -4,7 +4,10 @@ namespace IzBundle\Form;
 
 use AppBundle\Form\AppDateType;
 use AppBundle\Form\BaseType;
+use IzBundle\Entity\Afsluiting;
 use IzBundle\Entity\IzDeelnemer;
+use IzBundle\Entity\IzKlant;
+use IzBundle\Entity\IzVrijwilliger;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -17,6 +20,14 @@ class IzDeelnemerCloseType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        if ($options['data'] instanceof IzKlant) {
+            $doelgroepen = Afsluiting::DOELGROEP_KLANT;
+        } elseif ($options['data'] instanceof IzVrijwilliger) {
+            $doelgroepen = Afsluiting::DOELGROEP_VRIJWILLIGER;
+        } else {
+            $doelgroepen = 0;
+        }
+
         $builder
             ->add('afsluitdatum', AppDateType::class, [
                 'label' => 'Afsluitdatum',
@@ -25,6 +36,7 @@ class IzDeelnemerCloseType extends AbstractType
             ])
             ->add('afsluiting', AfsluitingSelectType::class, [
                 'required' => true,
+                'doelgroepen' => $doelgroepen,
             ])
             ->add('submit', SubmitType::class)
         ;

--- a/templates/iz/afsluitredenen_deelnemer/index.html.twig
+++ b/templates/iz/afsluitredenen_deelnemer/index.html.twig
@@ -14,6 +14,9 @@
                     {{ knp_pagination_sortable(pagination, 'Naam', 'afsluitreden.naam') }}
                 </th>
                 <th>
+                    {{ knp_pagination_sortable(pagination, 'Doelgroepen', 'afsluitreden.doelgroepen') }}
+                </th>
+                <th>
                     {{ knp_pagination_sortable(pagination, 'Actief', 'afsluitreden.actief') }}
                 </th>
                 <th></th>
@@ -24,6 +27,13 @@
             <tr>
                 <td>
                     {{ entity.naam }}
+                </td>
+                <td>
+                    <ul class="list-inline">
+                        {% for doelgroep in entity.doelgroepen %}
+                            <li>{{ constant('IzBundle\\Entity\\Afsluiting::DOELGROEPEN_LABELS')[doelgroep] }}</li>
+                        {% endfor %}
+                    </ul>
                 </td>
                 <td>
                     {{ entity.actief ? 'Ja' : 'Nee' }}


### PR DESCRIPTION
@jtborger Ik heb het veld `doelgroepen` toegevoegd aan entity `Afsluiting`. Dit is een integer die een combinatie van bits representeert die aan of uit staan. Waarde 1 betekent voor deelnemers, 2 voor vrijwilligers, in de toekomst kunnen daar meer waarden bij komen (4, 8, 16, etc). De waarde drie betekent relevant voor zowel deelnemer als vrijwilliger. D.m.v. bitwise operators laat form `IzDeelnemerCloseType` alleen de relevante afsluitingen zien.

fixes #1160 