### PR TITLE
Toevoegen zoekfunctie matchingsinformatie #1464

### DIFF
--- a/src/IzBundle/Controller/HulpaanbiedingenController.php
+++ b/src/IzBundle/Controller/HulpaanbiedingenController.php
@@ -80,6 +80,7 @@ class HulpaanbiedingenController extends AbstractChildController
                     'klant' => ['voornaam', 'achternaam', 'geslacht', 'geboortedatumRange', 'stadsdeel'],
                     'hulpvraagsoort',
                     'doelgroep',
+                    'zoekterm',
                     'filter',
                 ],
             ]);

--- a/src/IzBundle/Controller/HulpvragenController.php
+++ b/src/IzBundle/Controller/HulpvragenController.php
@@ -81,6 +81,7 @@ class HulpvragenController extends AbstractChildController
                     'vrijwilliger' => ['voornaam', 'achternaam', 'geslacht', 'geboortedatumRange', 'stadsdeel'],
                     'hulpvraagsoort',
                     'doelgroep',
+                    'zoekterm',
                     'filter',
                 ],
             ]);

--- a/src/IzBundle/Filter/HulpaanbodFilter.php
+++ b/src/IzBundle/Filter/HulpaanbodFilter.php
@@ -111,7 +111,10 @@ class HulpaanbodFilter implements FilterInterface
                     $builder->join('hulpaanbod.verslagen', 'verslag');
                 }
                 $builder
-                    ->andWhere('verslag.opmerking LIKE :zoekterm_'.$i)
+                    ->andWhere($builder->expr()->orX(
+                        'hulpaanbod.info LIKE :zoekterm_'.$i,
+                        'verslag.opmerking LIKE :zoekterm_'.$i,
+                    ))
                     ->setParameter('zoekterm_'.$i, '%'.$zoekterm.'%')
                 ;
             }

--- a/src/IzBundle/Filter/HulpvraagFilter.php
+++ b/src/IzBundle/Filter/HulpvraagFilter.php
@@ -111,7 +111,10 @@ class HulpvraagFilter implements FilterInterface
                     $builder->join('hulpvraag.verslagen', 'verslag');
                 }
                 $builder
-                    ->andWhere('verslag.opmerking LIKE :zoekterm_'.$i)
+                    ->andWhere($builder->expr()->orX(
+                        'hulpvraag.info LIKE :zoekterm_'.$i,
+                        'verslag.opmerking LIKE :zoekterm_'.$i,
+                    ))
                     ->setParameter('zoekterm_'.$i, '%'.$zoekterm.'%')
                 ;
             }

--- a/templates/iz/hulpaanbiedingen/view.html.twig
+++ b/templates/iz/hulpaanbiedingen/view.html.twig
@@ -94,6 +94,18 @@
                     <thead>
                         {{ form_start(filter) }}
                             <tr>
+                                <th colspan="5">
+                                    {{ form_widget(filter.zoekterm) }}
+                                    {{ form_errors(filter.zoekterm) }}
+                                </th>
+                                <th colspan="4">
+                                    {{ form_widget(filter.matching) }}
+                                </th>
+                                <th>
+                                    {{ form_widget(filter.filter) }}
+                                </th>
+                            </tr>
+                            <tr>
                                 <th>
                                     {{ form_widget(filter.startdatum) }}
                                     {{ form_errors(filter.startdatum) }}
@@ -126,12 +138,11 @@
                                     {{ form_widget(filter.doelgroep) }}
                                     {{ form_errors(filter.doelgroep) }}
                                 </th>
-                                <th colspan="2">
-                                    {{ form_widget(filter.matching) }}
-                                    {{ form_errors(filter.matching) }}
+                                <th>
                                 </th>
                                 <th>
-                                    {{ form_widget(filter.filter) }}
+                                </th>
+                                <th>
                                 </th>
                             </tr>
                         {{ form_end(filter) }}

--- a/templates/iz/hulpvragen/view.html.twig
+++ b/templates/iz/hulpvragen/view.html.twig
@@ -84,6 +84,18 @@
                     <thead>
                         {{ form_start(filter) }}
                             <tr>
+                                <th colspan="5">
+                                    {{ form_widget(filter.zoekterm) }}
+                                    {{ form_errors(filter.zoekterm) }}
+                                </th>
+                                <th colspan="4">
+                                    {{ form_widget(filter.matching) }}
+                                </th>
+                                <th>
+                                    {{ form_widget(filter.filter) }}
+                                </th>
+                            </tr>
+                            <tr>
                                 <th>
                                     {{ form_widget(filter.startdatum) }}
                                     {{ form_errors(filter.startdatum) }}
@@ -116,12 +128,11 @@
                                     {{ form_widget(filter.doelgroep) }}
                                     {{ form_errors(filter.doelgroep) }}
                                 </th>
-                                <th colspan="2">
-                                    {{ form_widget(filter.matching) }}
-                                    {{ form_errors(filter.matching) }}
+                                <th>
                                 </th>
                                 <th>
-                                    {{ form_widget(filter.filter) }}
+                                </th>
+                                <th>
                                 </th>
                             </tr>
                         {{ form_end(filter) }}


### PR DESCRIPTION
Een zoekfunctie voor verslagen was onlangs al toegevoegd. Ditzelfde veld `zoekterm` doorzoekt nu ook de matchingsinformatie.

fixes #1464