### PR TITLE
Startdatum toegang overig ook voor illegaal #1758

### DIFF
--- a/config/packages/parameters.yaml
+++ b/config/packages/parameters.yaml
@@ -90,7 +90,8 @@ parameters:
   iz_hulpsoorten_zonder_koppelingen:
     - timeout
     - 'Time out'
-  amoc_verblijfsstatus: 'Europees Burger (Niet Nederlands)'
+  verblijfsstatus_europees_burger: 'Europees Burger (Niet Nederlands)'
+  verblijfsstatus_illegaal: 'Illegaal (uit buiten Europa)'
   wachtlijst_locaties:
     - 'Wachtlijst T6 Project'
     - 'Wachtlijst Economisch Daklozen'

--- a/config/services/inloop/services.yaml
+++ b/config/services/inloop/services.yaml
@@ -19,7 +19,8 @@ services:
         bind:
             $tbc_countries: '%tbc_countries%'
             $accessStrategies: '%access_strategies%'
-            $amocVerblijfsstatus: '%amoc_verblijfsstatus%'
+            $verblijfsstatusEuropeesBurger: '%verblijfsstatus_europees_burger%'
+            $verblijfsstatusIllegaal: '%verblijfsstatus_illegaal%'
 
     InloopBundle\Command\:
         resource: '%kernel.project_dir%/src/InloopBundle/Command'
@@ -90,7 +91,8 @@ services:
             - {'name': 'inloop.access_strategy', priority: 100}
 
     InloopBundle\Strategy\AmocWestStrategy:
-        tags: [{'name': 'inloop.access_strategy', priority: 90}]
+        tags:
+            - {'name': 'inloop.access_strategy', priority: 90}
 
     InloopBundle\Strategy\VillaWesterweideStrategy:
         tags:

--- a/src/InloopBundle/Controller/IntakesController.php
+++ b/src/InloopBundle/Controller/IntakesController.php
@@ -47,15 +47,24 @@ class IntakesController extends AbstractController
 
     protected $accessStrategies = [];
 
-    protected $amocVerblijfsstatus = "";
+    protected $verblijfsstatusEuropeesBurger;
 
-    public function __construct(IntakeDaoInterface $dao, ContainerInterface $container, $tbc_countries = [], $accessStrategies = [], $amocVerblijfsstatus = '')
-    {
+    protected $verblijfsstatusIllegaal;
+
+    public function __construct(
+        IntakeDaoInterface $dao,
+        ContainerInterface $container,
+        $tbc_countries = [],
+        $accessStrategies = [],
+        $verblijfsstatusEuropeesBurger = '',
+        $verblijfsstatusIllegaal = ''
+    ) {
         $this->container = $container;
         $this->dao = $dao;
         $this->tbc_countries = $tbc_countries;
         $this->accessStrategies = $accessStrategies;
-        $this->amocVerblijfsstatus = $amocVerblijfsstatus;
+        $this->verblijfsstatusEuropeesBurger = $verblijfsstatusEuropeesBurger;
+        $this->verblijfsstatusIllegaal = $verblijfsstatusIllegaal;
     }
 
     /**
@@ -213,7 +222,8 @@ class IntakesController extends AbstractController
     {
         return [
             'tbc_countries' => $this->tbc_countries,
-            'amocVerblijfsstatus' => $this->amocVerblijfsstatus,
+            'verblijfsstatus_europees_burger' => $this->verblijfsstatusEuropeesBurger,
+            'verblijfsstatus_illegaal' => $this->verblijfsstatusIllegaal,
             'accessStrategies' => json_encode($this->accessStrategies),
         ];
     }

--- a/src/InloopBundle/Form/ToegangType.php
+++ b/src/InloopBundle/Form/ToegangType.php
@@ -91,7 +91,7 @@ class ToegangType extends AbstractType
                 'locatietypes' => ['Inloop'],
             ])
             ->add('overigenToegangVan', AppDateType::class, [
-                'label' => 'Startdatum toegang overig)',
+                'label' => 'Startdatum toegang overig',
                 'required'=>false,
             ])
             ->add('gebruikersruimte', LocatieSelectType::class, [

--- a/src/InloopBundle/Strategy/AmocStrategy.php
+++ b/src/InloopBundle/Strategy/AmocStrategy.php
@@ -9,12 +9,7 @@ final class AmocStrategy implements StrategyInterface
 {
     private const ACCESS_STRATEGY_NAME = 'amoc_stadhouderskade';
 
-    /** @var Locatie */
-    private $locatie;
-
     private $amoc_locaties = [];
-
-    private $amocVerblijfsstatus = '';
 
     /**
      * Deze strategie houdt in dat alleen voor de AMOC locaties mensen geselecteerd worden die ofwel geen specifieke
@@ -22,10 +17,9 @@ final class AmocStrategy implements StrategyInterface
      *
      * Er wordt niet gekeken naar verblijfsstatus.
      */
-    public function __construct(array $accessStrategies, $amocVerblijfsstatus)
+    public function __construct(array $accessStrategies)
     {
         $this->amoc_locaties = $accessStrategies[self::ACCESS_STRATEGY_NAME];
-        $this->amocVerblijfsstatus = $amocVerblijfsstatus;
     }
 
     public function supports(Locatie $locatie): bool

--- a/src/InloopBundle/Strategy/ToegangOverigStrategy.php
+++ b/src/InloopBundle/Strategy/ToegangOverigStrategy.php
@@ -2,7 +2,6 @@
 
 namespace InloopBundle\Strategy;
 
-use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\QueryBuilder;
 use InloopBundle\Entity\Locatie;
 
@@ -10,24 +9,17 @@ final class ToegangOverigStrategy implements StrategyInterface
 {
     private $verblijsstatusNietRechthebbend;
 
-    /** @var Locatie */
-    private $locatie;
-
     /** @var array */
     private $intakeLocaties = [];
 
-    /** @var EntityManagerInterface */
-    private $em;
-
-    public function __construct(array $accessStrategies, string $amocVerblijfsstatus, EntityManagerInterface $em)
+    public function __construct(array $accessStrategies, string $verblijfsstatusEuropeesBurger)
     {
-        $this->em = $em;
         array_walk($accessStrategies, function ($v, $k) {
             $this->intakeLocaties = array_merge($this->intakeLocaties, $v);
         });
 
         $this->intakeLocaties = array_unique($this->intakeLocaties);
-        $this->verblijsstatusNietRechthebbend = $amocVerblijfsstatus;
+        $this->verblijsstatusNietRechthebbend = $verblijfsstatusEuropeesBurger;
     }
 
     public function supports(Locatie $locatie): bool

--- a/templates/inloop/intakes/_form_scripts.html.twig
+++ b/templates/inloop/intakes/_form_scripts.html.twig
@@ -7,15 +7,13 @@
                 var toegang = function (name) {
 
                     var check = function () {
-
-
-                        var statusId =  $("#" + name + "_toegang_verblijfsstatus").find(":selected").first().text()
-                        var intakelocatie =  $("#" + name + "_toegang_intakelocatie").find(":selected").first().text()
+                        var status = $("#" + name + "_toegang_verblijfsstatus").find(":selected").first().text()
+                        var intakelocatie = $("#" + name + "_toegang_intakelocatie").find(":selected").first().text()
                         var accessStrategies = {{ accessStrategies|raw }};
-                        var toegang_intakelocatieElm =  $("#" + name + "_toegang_toegangIntakelocatie");
+                        var toegang_intakelocatieElm = $("#" + name + "_toegang_toegangIntakelocatie");
 
-                        if (statusId == "{{ amocVerblijfsstatus }}") //AMOC (+west) klant
-                        {
+                        const statuses = ["{{ verblijfsstatus_europees_burger }}", "{{ verblijfsstatus_illegaal }}"];
+                        if (statuses.includes(status)) {
                             // $("#" + name + "_toegang_overigenToegangVan").prop("disabled", false);
                             var sixMonths = new Date();
                             var m = sixMonths.getMonth();
@@ -30,14 +28,10 @@
 
                             }
                             $("#" + name + "_toegang_overigenToegangVan").prop("readonly",false);
-                        }
-                        else  // niet amoc, geen datum regels.
-                        {
+                        } else {
                             $("#" + name + "_toegang_overigenToegangVan").val(null);
                             $("#" + name + "_toegang_overigenToegangVan").prop("readonly","readonly");
                         }
-
-
                     }//end check()
 
                     var verblijfsstatusElm = $("#" + name + "_toegang_verblijfsstatus");

--- a/templates/inloop/intakes/edit_toegang.html.twig
+++ b/templates/inloop/intakes/edit_toegang.html.twig
@@ -12,7 +12,7 @@
     <ol>
         <li>Klanten hebben geen toegang tot een van de inloophuizen wanneer het vinkje 'Toegang inloophuizen' <b>uit</b> staat.</li>
         <li>Alleen inloophuizen zonder specifieke toegangsregels zijn voor algemeen gebruik toegankelijk.</li>
-        <li>Klanten met de verblijfsstatus '{{ amocVerblijfsstatus }}', hebben alleen toegang tot de algemene inloophuizen vanaf de 'Startdatum toegang overig'.</li>
+        <li>Klanten met de verblijfsstatus '{{ verblijfsstatus_europees_burger }}', hebben alleen toegang tot de algemene inloophuizen vanaf de 'Startdatum toegang overig'.</li>
         <li>Extra of specifieke toegang kan via 'Specifieke locaties' worden opgegeven (en staat los van alle andere regels).</li>
         <li>Afhankelijk van de intakelocatie: </li>
         <ol>


### PR DESCRIPTION
Het veld "Startdatum toegang overig" wordt nu ook enabled als verblijfsstatus "Illegaal (uit buiten Europa)" is geselecteerd. Waarschijnlijk moet er ook e.e.a. aan de toegangsstrategieën worden aangepast. @jtborger @dvleeuwen Kan een van jullie daar aanwijzingen voor geven?

@jtborger De naamgeving van property `amoc_verblijfsstatus` en variabele `$amocVerblijfsstatus` vind ik verwarrend, omdat de waarde "Europees Burger (Niet Nederlands)" wordt toegekend (zie config/packages/parameters.yaml). Ik heb dit overal hernoemd naar naar `verblijfsstatus_europees_burger` en `$verblijfsstatusEuropeesBurger`. Nu valt mij op dat er in src/InloopBundle/Strategy/ToegangOverigStrategy.php in de constructor onderstaande staat. Dat lijkt me niet te kloppen. Is de naamgeving van variabele `$verblijsstatusNietRechthebbend` hier ongelukkig gekozen, of moet er een property `verblijfsstatus_niet_rechthebbend` bijkomen en had die hier geïnjecteerd moeten worden.

```
        $this->verblijsstatusNietRechthebbend = $verblijfsstatusEuropeesBurger;
```

fixes #1758 