### PR TITLE
Verhuurder filter 'gekoppeld' werkte niet goed.

### DIFF
--- a/src/TwBundle/Controller/VerhuurdersController.php
+++ b/src/TwBundle/Controller/VerhuurdersController.php
@@ -11,6 +11,7 @@ use AppBundle\Form\ConfirmationType;
 use AppBundle\Form\KlantFilterType;
 use AppBundle\Service\KlantDaoInterface;
 use Doctrine\ORM\QueryBuilder;
+use Symfony\Component\HttpFoundation\Request;
 use TwBundle\Entity\Verhuurder;
 use TwBundle\Form\VerhuurderCloseType;
 use TwBundle\Form\VerhuurderFilterType;

--- a/src/TwBundle/Entity/Deelnemer.php
+++ b/src/TwBundle/Entity/Deelnemer.php
@@ -509,18 +509,5 @@ abstract class Deelnemer implements KlantRelationInterface
 
     abstract public function getHuurovereenkomsten();
 
-    public function isGekoppeld()
-    {
-        $today = new \DateTime('today');
-        foreach ($this->getHuurovereenkomsten() as $hoe) {
-            /** @var Huurovereenkomst $hoe */
-            if ($hoe->isReservering() == false && $hoe->isActief() == true && ($hoe->getAfsluitdatum() == null || $hoe->getAfsluitdatum() > $today) && $hoe->getStartdatum() != null
-                && $this->getAfsluitdatum() == null
-            ) {
-                return true;
-            }
-        }
-
-        return false;
-    }
+    abstract public function isGekoppeld();
 }

--- a/src/TwBundle/Entity/Klant.php
+++ b/src/TwBundle/Entity/Klant.php
@@ -495,6 +495,27 @@ class Klant extends Deelnemer
         return $this;
     }
 
+    public function isGekoppeld()
+    {
+
+
+        $today = new \DateTime('today');
+        $hoes = $this->getHuurovereenkomsten();
+        foreach ($hoes as $hoe) {
+            /** @var Huurovereenkomst $hoe */
+            if ($hoe->isReservering() == false
+                && $hoe->isActief() == true
+                && ($hoe->getAfsluitdatum() == null || $hoe->getAfsluitdatum() > $today)
+                && $hoe->getStartdatum() != null
+
+                //&& $this->getAfsluitdatum() == null
+            ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
 
     /**

--- a/src/TwBundle/Entity/Verhuurder.php
+++ b/src/TwBundle/Entity/Verhuurder.php
@@ -176,6 +176,38 @@ class Verhuurder extends Deelnemer
         return $huurovereenkomsten;
     }
 
+    public function isGekoppeld()
+    {
+        //los van een eventuele koppeling moet worden gekeken of er een open huuraanbieding is.
+
+        $has = $this->getHuuraanbiedingen();
+        foreach($has as $ha) {
+            if (!$ha->getHuurovereenkomst()){
+
+                $afsluitdatum = $ha->getAfsluitdatum();
+                if(null === $afsluitdatum) return false;
+            }
+        }
+
+
+        //er zijn geen open huuraanbiedingen, dan kijken naar de huurovereenkomsten
+        $today = new \DateTime('today');
+        $hoes = $this->getHuurovereenkomsten();
+        foreach ($hoes as $hoe) {
+            /** @var Huurovereenkomst $hoe */
+            if ($hoe->isReservering() == false
+                && $hoe->isActief() == true
+                && ($hoe->getAfsluitdatum() == null || $hoe->getAfsluitdatum() > $today)
+                && $hoe->getStartdatum() != null
+
+            ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public function getPandeigenaar()
     {
         return $this->pandeigenaar;

--- a/src/TwBundle/Service/VerhuurderDao.php
+++ b/src/TwBundle/Service/VerhuurderDao.php
@@ -5,6 +5,7 @@ namespace TwBundle\Service;
 use AppBundle\Filter\FilterInterface;
 use AppBundle\Model\UsesKlantTrait;
 use AppBundle\Service\AbstractDao;
+use Doctrine\Common\Collections\ArrayCollection;
 use Knp\Component\Pager\Pagination\PaginationInterface;
 use TwBundle\Entity\Verhuurder;
 
@@ -48,10 +49,35 @@ class VerhuurderDao extends AbstractDao implements VerhuurderDaoInterface
             ->leftJoin('verhuurder.project','project')
             ->andWhere('afsluiting.tonen IS NULL OR afsluiting.tonen = true')
         ;
-//        $builder = $this->repository->createQueryBuilder($this->alias)
-//            ->innerJoin($this->alias.'.klant', 'klant')
-//        ;
-        return parent::doFindAll($builder, $page, $filter);
+
+        /**
+         * Op de een of andere manier is het niet goed mogelijk dit via Doctrine te filteren.
+         * Het kan vast, maar ik krijg het nu niet voor elkaar.
+         * Punt is dat de join op huuraanbiedingen en huurovererenkomsten als cartesiaans product wordt gemaakt.
+         * en het er niet omgaat dat er een mogelijke match is in de join, maar dat de meest recente koppeling lopend is of niet.
+         * Dus moet je met WINDOW functies gaan werken,
+         * of self joins of wat dan ook.
+         * En dat is in doctrine niet zo fijn.
+         * Dus dan maar zo, na veel te lang geprobeerd te hebben...
+         *
+         *
+         */
+        if(null !== $filter->gekoppeld)
+        {
+            $result = parent::doFindAll($builder,null, $filter);
+            $filteredResult = new ArrayCollection();
+
+            foreach($result as $row)
+            {
+                if($filter->gekoppeld === $row->isGekoppeld())
+                {
+                    $filteredResult->add($row);
+                }
+            }
+            return $this->paginator->paginate($filteredResult, $page, $this->itemsPerPage, $this->paginationOptions);
+        }
+
+        return parent::doFindAll($builder,$page, $filter);
     }
 
 

--- a/templates/tw/klanten/index.html.twig
+++ b/templates/tw/klanten/index.html.twig
@@ -14,7 +14,7 @@
         <thead>
             {{ form_start(filter) }}
                 <tr>
-                    <th colspan="2"></th>
+
                     <th>
                         {{ form_label(filter.medewerker) }}
                         {{ form_widget(filter.medewerker) }}
@@ -149,7 +149,8 @@
                         {{ form_row(filter._token) }}
                     </th>
                 </tr>
-            </thead>{{ form_end(filter,{'render_rest':false}) }}
+            </thead>
+        {{ form_end(filter,{'render_rest':false}) }}
         <tbody>
             {% for klant in pagination %}
                 <tr data-href="{{ path(route_base~'view', {id: klant.id}) }}">

--- a/tests/TwBundle/Filter/VerhuurderFilterTest.php
+++ b/tests/TwBundle/Filter/VerhuurderFilterTest.php
@@ -17,8 +17,13 @@ class VerhuurderFilterTest extends DoctrineTestCase
         // empty filter
         $builder = $this->getQueryBuilder();
         $filter->applyTo($builder);
-        $expected = 'SELECT FROM TwBundle\Entity\Verhuurder verhuurder';
-        $this->assertEquals($expected, (string) $builder);
+        $expected = 'SELECT FROM TwBundle\Entity\Verhuurder verhuurder
+            LEFT JOIN verhuurder.huuraanbiedingen huuraanbod WITH huuraanbod.afsluiting IS NULL 
+            LEFT JOIN huuraanbod.huurovereenkomst huurovereenkomst WITH huurovereenkomst.isReservering = false
+                    AND huurovereenkomst.startdatum IS NOT NULL
+                    AND (huurovereenkomst.afsluitdatum IS NULL OR huurovereenkomst.afsluitdatum > :today) 
+            WHERE huurovereenkomst IS NULL';
+        $this->assertEqualsIgnoringWhitespace($expected, (string) $builder);
 
         // gekoppeld
         $builder = $this->getQueryBuilder();
@@ -31,6 +36,7 @@ class VerhuurderFilterTest extends DoctrineTestCase
                 AND huurovereenkomst.startdatum IS NOT NULL
                 AND (huurovereenkomst.afsluitdatum IS NULL OR huurovereenkomst.afsluitdatum > :today)
             WHERE huurovereenkomst IS NOT NULL';
+
         $this->assertEqualsIgnoringWhitespace($expected, (string) $builder);
 
         // niet gekoppeld


### PR DESCRIPTION
Geprobeerd in Doctrine op telossen. Bleek te ingewikkeld voor nu. In Dao programmatisch gefilterd.