### PR TITLE
Fixes #1780 vorm van Overeenkomst ambiguiteit tussen Huuraanbod en Hu…

### DIFF
--- a/migrations/2024/Version20240625083649.php
+++ b/migrations/2024/Version20240625083649.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20240625083649 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE tw_huurovereenkomsten ADD vormVanOvereenkomst_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE tw_huurovereenkomsten ADD CONSTRAINT FK_98F99DF6621E13D7 FOREIGN KEY (vormVanOvereenkomst_id) REFERENCES tw_vormvanovereenkomst (id)');
+
+        $this->addSql('CREATE INDEX IDX_98F99DF6621E13D7 ON tw_huurovereenkomsten (vormVanOvereenkomst_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE tw_huurovereenkomsten DROP FOREIGN KEY FK_98F99DF6621E13D7');
+        $this->addSql('DROP INDEX IDX_98F99DF6621E13D7 ON tw_huurovereenkomsten');
+        $this->addSql('ALTER TABLE tw_huurovereenkomsten DROP vormVanOvereenkomst_id');
+
+    }
+}

--- a/migrations/2024/Version20240625083918.php
+++ b/migrations/2024/Version20240625083918.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20240625083918 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql("INSERT IGNORE INTO tw_vormvanovereenkomst (label, startdate)
+                            SELECT DISTINCT vorm, '2021-07-01' FROM tw_huurovereenkomsten");
+
+        $this->addSql("UPDATE tw_huurovereenkomsten ho RIGHT JOIN tw_vormvanovereenkomst vvo
+                            ON vvo.label = ho.vorm
+                            SET ho.vormVanOvereenkomst_id = vvo.id;");
+
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+
+    }
+}

--- a/src/TwBundle/Controller/VormVanOvereenkomstController.php
+++ b/src/TwBundle/Controller/VormVanOvereenkomstController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace TwBundle\Controller;
+
+use AppBundle\Controller\AbstractController;
+use TwBundle\Entity\VormVanOvereenkomst;
+use TwBundle\Form\VormVanOvereenkomstSelectType;
+
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\HttpFoundation\Request;
+use TwBundle\Form\VormVanOvereenkomstType;
+use TwBundle\Service\VormVanOvereenkomstDaoInterface;
+
+/**
+ * @Route("/admin/vormvanovereenkomst")
+ */
+class VormVanOvereenkomstController extends AbstractController
+{
+    protected $entityName = 'vormvanovereenkomst';
+    protected $entityClass = VormVanOvereenkomst::class;
+    protected $formClass = VormVanOvereenkomstType::class;
+    protected $baseRouteName = 'tw_vormvanovereenkomst_';
+    protected $title = 'Vorm van overeenkomst';
+
+    /**
+     * @var VormVanOvereenkomstDaoInterface
+     */
+    protected $dao;
+
+    public function __construct(VormVanOvereenkomstDaoInterface $dao)
+    {
+        $this->dao = $dao;
+    }
+
+    /**
+     * @Route("/{id}/view")
+     */
+    public function viewAction(Request $request, $id)
+    {
+        return $this->redirectToIndex();
+    }
+
+    protected function redirectToView($entity)
+    {
+        return $this->redirectToIndex();
+    }
+}

--- a/src/TwBundle/Entity/Huurovereenkomst.php
+++ b/src/TwBundle/Entity/Huurovereenkomst.php
@@ -74,6 +74,13 @@ class Huurovereenkomst
     private $vorm;
 
     /**
+     * @var VormVanOvereenkomst
+     * @ORM\ManyToOne(targetEntity="TwBundle\Entity\VormVanOvereenkomst",cascade={"persist"})
+     * @Gedmo\Versioned
+     */
+    private $vormVanOvereenkomst;
+
+    /**
      * @ORM\Column(type="date", nullable=true)
      * @Gedmo\Versioned
      */
@@ -429,4 +436,16 @@ class Huurovereenkomst
         $this->huurovereenkomstType = $huurovereenkomstType;
         return $this;
     }
+
+    public function getVormVanOvereenkomst(): ?VormVanOvereenkomst
+    {
+        return $this->vormVanOvereenkomst;
+    }
+
+    public function setVormVanOvereenkomst(?VormVanOvereenkomst $vormVanOvereenkomst): void
+    {
+        $this->vormVanOvereenkomst = $vormVanOvereenkomst;
+    }
+
+
 }

--- a/src/TwBundle/Entity/VormVanOvereenkomst.php
+++ b/src/TwBundle/Entity/VormVanOvereenkomst.php
@@ -2,6 +2,7 @@
 
 namespace TwBundle\Entity;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 
@@ -33,6 +34,12 @@ class VormVanOvereenkomst
      */
     private $huuraanbod;
 
+    /**
+     * @var Huurovereenkomst[]
+     * @ORM\OneToMany(targetEntity="Huurovereenkomst", mappedBy="vormVanOvereenkomst")
+     */
+    private $huurovereenkomsten;
+
 
     /**
      * @ORM\Column(type="date")
@@ -52,6 +59,8 @@ class VormVanOvereenkomst
     public function __construct()
     {
         $this->startdate = new \DateTime();
+        $this->huuraanbod = new ArrayCollection();
+        $this->huurovereenkomsten = new ArrayCollection();
     }
 
     public function __toString()
@@ -127,4 +136,29 @@ class VormVanOvereenkomst
     {
         $this->huuraanbod = $huuraanbod;
     }
+
+    public function getHuurovereenkomsten(): array
+    {
+        return $this->huurovereenkomsten;
+    }
+
+    public function addHuurovereenkomst(Huurovereenkomst $huurovereenkomst): void
+    {
+        if(!$this->huurovereenkomsten->contains($huurovereenkomst))
+        {
+            $this->huurovereenkomsten->add($huurovereenkomst);
+            $huurovereenkomst->setVormVanOvereenkomst($this);
+        }
+    }
+
+    public function removeHuurovereenkomst(Huurovereenkomst $huurovereenkomst): void
+    {
+        if(!$this->huurovereenkomsten->contains($huurovereenkomst))
+        {
+            $this->huurovereenkomsten->removeElement($huurovereenkomst);
+            $huurovereenkomst->setVormVanOvereenkomst(null);
+        }
+    }
+
+
 }

--- a/src/TwBundle/Form/HuuraanbodType.php
+++ b/src/TwBundle/Form/HuuraanbodType.php
@@ -31,7 +31,7 @@ class HuuraanbodType extends AbstractType
             )
             ->add('project', ProjectSelectType::class)
             ->add('startdatum', AppDateType::class)
-            ->add('vormvanovereenkomst', VormVanOvereenkomstType::class,[
+            ->add('vormvanovereenkomst', VormVanOvereenkomstSelectType::class,[
 
             ])
             ->add('datumToestemmingAangevraagd', AppDateType::class, [

--- a/src/TwBundle/Form/HuurovereenkomstType.php
+++ b/src/TwBundle/Form/HuurovereenkomstType.php
@@ -53,6 +53,9 @@ class HuurovereenkomstType extends AbstractType
                 'required' => false,
                 'choices' => Huurovereenkomst::getVormChoices(),
             ])
+            ->add('vormVanOvereenkomst',VormVanOvereenkomstSelectType::class,[
+                'required'=>false,
+            ])
             ->add('huurovereenkomstType')
 
             ->add('submit', SubmitType::class, ['label' => 'Opslaan'])

--- a/src/TwBundle/Form/VormVanOvereenkomstSelectType.php
+++ b/src/TwBundle/Form/VormVanOvereenkomstSelectType.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace TwBundle\Form;
+
+use TwBundle\Entity\VormVanOvereenkomst;
+use Doctrine\ORM\EntityRepository;
+
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class VormVanOvereenkomstSelectType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'class' => VormVanOvereenkomst::class,
+            'query_builder' => function (EntityRepository $repository) {
+                return $repository->createQueryBuilder('vormvanovereenkomst')
+                    ->orderBy('vormvanovereenkomst.id');
+            },
+            'label' => 'Vorm van overeenkomst'
+//            'preferred_choices' => function (Land $land) {
+//                return in_array($land->getNaam(), ['Nederland', 'Onbekend']);
+//            },
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParent(): ?string
+    {
+        return EntityType::class;
+    }
+}

--- a/src/TwBundle/Form/VormVanOvereenkomstType.php
+++ b/src/TwBundle/Form/VormVanOvereenkomstType.php
@@ -2,30 +2,61 @@
 
 namespace TwBundle\Form;
 
-use TwBundle\Entity\VormVanOvereenkomst;
-use Doctrine\ORM\EntityRepository;
-
-use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use AppBundle\Event\DienstenLookupEvent;
+use AppBundle\Event\Events;
+use AppBundle\Form\AppDateType;
+use AppBundle\Form\AppTextareaType;
+use AppBundle\Form\BaseType;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use TwBundle\Entity\Klant;
+use TwBundle\Entity\SuperVerslag;
+use TwBundle\Entity\Verslag;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use TwBundle\Entity\VormVanOvereenkomst;
 
 class VormVanOvereenkomstType extends AbstractType
 {
+    /**
+     * @var EventDispatcherInterface $eventDispatcher
+     */
+    private $eventDispatcher;
+    public function __construct(EventDispatcherInterface $eventDispatcher)
+    {
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('label')
+            ->add('startdate', AppDateType::class)
+            ->add('enddate', AppDateType::class, [
+                'required'=>false,
+            ])
+            ->add('submit', SubmitType::class, ['label' => 'Opslaan'])
+
+        ;
+
+    }
+
     /**
      * {@inheritdoc}
      */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-            'class' => VormVanOvereenkomst::class,
-            'query_builder' => function (EntityRepository $repository) {
-                return $repository->createQueryBuilder('vormvanovereenkomst')
-                    ->orderBy('vormvanovereenkomst.id');
-            },
-            'label' => 'Vorm van overeenkomst'
-//            'preferred_choices' => function (Land $land) {
-//                return in_array($land->getNaam(), ['Nederland', 'Onbekend']);
-//            },
+            'data_class' => VormVanOvereenkomst::class,
         ]);
     }
 
@@ -34,6 +65,6 @@ class VormVanOvereenkomstType extends AbstractType
      */
     public function getParent(): ?string
     {
-        return EntityType::class;
+        return BaseType::class;
     }
 }

--- a/src/TwBundle/Service/VormVanOvereenkomstDao.php
+++ b/src/TwBundle/Service/VormVanOvereenkomstDao.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace TwBundle\Service;
+
+use AppBundle\Service\AbstractDao;
+
+use TwBundle\Entity\VormVanOvereenkomst;
+
+class VormVanOvereenkomstDao extends AbstractDao implements VormVanOvereenkomstDaoInterface
+{
+    protected $paginationOptions = [
+        'defaultSortFieldName' => 'vormvanovereenkomst.label',
+        'defaultSortDirection' => 'asc',
+        'sortFieldWhitelist' => [
+            'vormvanovereenkomst.label',
+            'project.startdate',
+        ],
+    ];
+
+    protected $class = VormVanOvereenkomst::class;
+
+    protected $alias = 'vormvanovereenkomst';
+
+    public function create(VormVanOvereenkomst $vormVanOvereenkomst)
+    {
+        $this->doCreate($vormVanOvereenkomst);
+    }
+
+    public function update(VormVanOvereenkomst $vormVanOvereenkomst)
+    {
+        $this->doUpdate($vormVanOvereenkomst);
+    }
+
+    public function delete(VormVanOvereenkomst $vormVanOvereenkomst)
+    {
+        $this->doDelete($vormVanOvereenkomst);
+    }
+
+}

--- a/src/TwBundle/Service/VormVanOvereenkomstDaoInterface.php
+++ b/src/TwBundle/Service/VormVanOvereenkomstDaoInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace TwBundle\Service;
+
+use AppBundle\Filter\FilterInterface;
+use Knp\Component\Pager\Pagination\PaginationInterface;
+use TwBundle\Entity\VormVanOvereenkomst;
+
+interface VormVanOvereenkomstDaoInterface
+{
+    /**
+     * @param int             $page
+     * @param FilterInterface $filter
+     *
+     * @return PaginationInterface
+     */
+    public function findAll($page = null, FilterInterface $filter = null);
+
+    /**
+     * @param int $id
+     *
+     * @return VormVanOvereenkomst
+     */
+    public function find($id);
+
+    /**
+     * @param VormVanOvereenkomst $entity
+     */
+    public function create(VormVanOvereenkomst $entity);
+
+    /**
+     * @param VormVanOvereenkomst $entity
+     */
+    public function update(VormVanOvereenkomst $entity);
+
+    /**
+     * @param VormVanOvereenkomst $entity
+     */
+    public function delete(VormVanOvereenkomst $entity);
+}

--- a/templates/tw/huurovereenkomsten/view.html.twig
+++ b/templates/tw/huurovereenkomsten/view.html.twig
@@ -59,8 +59,8 @@
         <dd>{{ entity.opzegbriefVerstuurd ? 'Ja' : 'Nee' }}</dd>
         <dt>Einddatum</dt>
         <dd>{{ entity.einddatum ? entity.einddatum|date('d-m-Y') }}</dd>
-        <dt>Vorm</dt>
-        <dd>{{ entity.vorm }}</dd>
+        <dt>Vorm van overeenkomst</dt>
+        <dd>{{ entity.vormVanOvereenkomst }}</dd>
         <dt>Type</dt>
         <dd>{{ entity.huurovereenkomstType }}</dd>
         <dt>Afsluitdatum</dt>

--- a/templates/tw/vorm_van_overeenkomst/index.html.twig
+++ b/templates/tw/vorm_van_overeenkomst/index.html.twig
@@ -1,0 +1,40 @@
+{% extends 'base.html.twig' %}
+{% import 'html.macro.twig' as html %}
+
+{% block content %}
+    <h1>{{ title }}</h1>
+    <p>
+        {{ html.addLink(path('tw_vormvanovereenkomst_add')) }}
+        {{ html.link('Vorm van overeenkomst toevoegen', path('tw_vormvanovereenkomst_add')) }}
+    </p>
+    <table class="table table-hover">
+        <tr>
+            <th>
+                {{ knp_pagination_sortable(pagination, '#', 'vormvanovereenkomst.id') }}
+            </th>
+            <th>
+                {{ knp_pagination_sortable(pagination, 'Label', 'vormvanovereenkomst.label') }}
+            </th>
+            <th>
+            </th>
+        </tr>
+        {% for vvo in pagination %}
+            <tr>
+                <td>
+                    {{ vvo.id }}
+                </td>
+                <td>
+                    {{ vvo.label }}
+                </td>
+                <td>
+                    {{ html.editLink(path('tw_vormvanovereenkomst_edit', {'id': vvo.id})) }}
+                    {{ html.deleteLink(path('tw_vormvanovereenkomst_delete', {'id': vvo.id})) }}
+                </td>
+            </tr>
+        {% endfor %}
+    </table>
+
+    <p>
+        {{ knp_pagination_render(pagination) }}
+    </p>
+{% endblock %}


### PR DESCRIPTION
…urovereenkomst.

In de laatste was het platte tekst vanuit een Choices array in de entity. Dit is raar, en er was inmiddels een tabel.
Twee migraties gemaakt, een voor relatie en de ander voor het migreren van de data. Kolom 'vorm' moet later verwijderd worden, is ticket voor aangemaakt.