### PR TITLE
Fix MW klanten query #1329

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -103,6 +103,8 @@ doctrine:
                 time_diff: DoctrineExtensions\Query\Mysql\TimeDiff
                 time_to_sec: DoctrineExtensions\Query\Mysql\TimeToSec
                 year: Luxifer\DQL\Datetime\Year
+            numeric_functions:
+                first: AppBundle\Doctrine\FirstFunction
             string_functions:
                 concat_ws: Luxifer\DQL\String\ConcatWs
                 replace: DoctrineExtensions\Query\Mysql\Replace

--- a/src/AppBundle/Doctrine/FirstFunction.php
+++ b/src/AppBundle/Doctrine/FirstFunction.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace AppBundle\Doctrine;
+
+use Doctrine\ORM\Query\AST\Functions\FunctionNode;
+use Doctrine\ORM\Query\AST\Subselect;
+use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
+
+/**
+ * FirstFunction ::=
+ *     "FIRST" "(" Subselect ")"
+ */
+class FirstFunction extends FunctionNode
+{
+    /**
+     * @var Subselect
+     */
+    private $subselect;
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->subselect = $parser->Subselect();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
+    }
+
+    public function getSql(SqlWalker $sqlWalker): string
+    {
+        return '(' . $this->subselect->dispatch($sqlWalker) . ' LIMIT 1)';
+    }
+}

--- a/src/MwBundle/Entity/Aanmelding.php
+++ b/src/MwBundle/Entity/Aanmelding.php
@@ -35,10 +35,6 @@ class Aanmelding extends MwDossierStatus
         return $return;
     }
 
-
-
-
-
     /**
      * @PrePersist
      * @param \Doctrine\ORM\Event\LifecycleEventArgs $event
@@ -62,6 +58,4 @@ class Aanmelding extends MwDossierStatus
     {
         parent::parentValidate($context,$payload);
     }
-
-
 }

--- a/src/MwBundle/Entity/MwDossierStatus.php
+++ b/src/MwBundle/Entity/MwDossierStatus.php
@@ -73,7 +73,7 @@ abstract class MwDossierStatus
     /**
      * @var Project
      *
-     * @ORM\ManyToOne(targetEntity="MwBundle\Entity\Project", inversedBy="aanmeldingen")
+     * @ORM\ManyToOne(targetEntity="MwBundle\Entity\Project")
      * @ORM\JoinColumn(nullable=false)
      * Assert\NotNull()
      * @Assert\Expression(
@@ -93,13 +93,12 @@ abstract class MwDossierStatus
     /**
      * @var BinnenViaOptieKlant
      *
-     * @ORM\ManyToOne(targetEntity="MwBundle\Entity\BinnenViaOptieKlant", inversedBy="aanmeldingen", )
+     * @ORM\ManyToOne(targetEntity="MwBundle\Entity\BinnenViaOptieKlant")
      * @ORM\JoinColumn(nullable=true, options={"default": 0})
      * @Gedmo\Versioned
      * @Assert\Expression("!this.isAangemeld() or value != null")
      */
     protected $binnenViaOptieKlant;
-
 
     public function __construct(Medewerker $medewerker = null)
     {

--- a/src/MwBundle/Form/KlantFilterType.php
+++ b/src/MwBundle/Form/KlantFilterType.php
@@ -3,34 +3,22 @@
 namespace MwBundle\Form;
 
 use AppBundle\Entity\Medewerker;
-use AppBundle\Entity\Werkgebied;
 use AppBundle\Form\AppDateRangeType;
 use AppBundle\Form\FilterType;
-use AppBundle\Form\MedewerkerFilterType as AppMedewerkerFilterType;
+use AppBundle\Form\JaNeeType;
 use AppBundle\Form\KlantFilterType as AppKlantFilterType;
-use AppBundle\Form\WerkgebiedSelectType;
 use Doctrine\ORM\EntityRepository;
-use GaBundle\Form\SelectieType;
-use InloopBundle\Entity\Locatie;
 use InloopBundle\Form\LocatieSelectType;
-use MwBundle\Entity\Aanmelding;
-use MwBundle\Entity\MwDossierStatus;
-use MwBundle\Entity\Project;
 use MwBundle\Entity\Verslag;
 use MwBundle\Filter\KlantFilter;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Validator\Constraints\Choice;
 
 class KlantFilterType extends AbstractType
 {
-    /**
-     * {@inheritdoc}
-     */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         if (array_key_exists('klant', $options['enabled_filters'])) {
@@ -38,44 +26,28 @@ class KlantFilterType extends AbstractType
                 'enabled_filters' => $options['enabled_filters']['klant'],
             ]);
         }
-//        if (array_key_exists('verslag', $options['enabled_filters'])) {
-//            $builder->add('verslag', EntityType::class, [
-//                'required' => false,
-//                'class'=>Medewerker::class,
-//
-//            ]);
-//        }
-        if (in_array('maatschappelijkWerker', $options['enabled_filters'])) {
 
+        if (in_array('maatschappelijkWerker', $options['enabled_filters'])) {
             $builder->add('maatschappelijkWerker', EntityType::class, [
                 'required' => false,
-                'class'=>Medewerker::class,
+                'class' => Medewerker::class,
                 'query_builder' => function (EntityRepository $repository) {
                     $builder = $repository->createQueryBuilder('medewerker')
-                        ->select("medewerker")
+                        ->select('medewerker')
                         ->innerJoin(Verslag::class, 'verslag', 'WITH', 'verslag.medewerker = medewerker')
                         ->where('verslag.type = 1')
-//                        ->orderBy('medewerker.voornaam')
                         ->groupBy('verslag.medewerker')
-                        ;
-                    $sql = $builder->getQuery()->getSQL();
-                    return $builder;
+                        ->orderBy('medewerker.voornaam')
                     ;
+
+                    return $builder;
                 },
             ]);
-
         }
         if (in_array('gebruikersruimte', $options['enabled_filters'])) {
             $builder->add('gebruikersruimte', LocatieSelectType::class, [
                 'required' => false,
                 'gebruikersruimte' => true,
-            ]);
-        }
-
-
-        if (in_array('laatsteIntakeDatum', $options['enabled_filters'])) {
-            $builder->add('laatsteIntakeDatum', AppDateRangeType::class, [
-                'required' => false,
             ]);
         }
 
@@ -93,17 +65,16 @@ class KlantFilterType extends AbstractType
 
         if (in_array('huidigeMwStatus', $options['enabled_filters'])) {
             $builder->add('huidigeMwStatus', ChoiceType::class, [
-
-                'choices'=>['Aangemeld'=>'Aanmelding','Afgesloten'=>'Afsluiting'],
+                'choices' => ['Aangemeld' => 'Aanmelding', 'Afgesloten' => 'Afsluiting'],
                 'required' => false,
-               'data'=>'Aanmelding'
-
+                'data' => 'Aanmelding',
             ]);
         }
 
-        if (in_array('gezin', $options['enabled_filters'])) {
-            $builder->add('isGezin', ChoiceType::class, [
-                'choices'=>['Ja'=>'1','Nee'=>'0', 'Onbekend'=>'null'],
+        if (in_array('isGezin', $options['enabled_filters'])) {
+            $builder->add('isGezin', JaNeeType::class, [
+                'placeholder' => 'Ja/Nee',
+                'expanded' => false,
                 'required' => false,
             ]);
         }
@@ -111,14 +82,10 @@ class KlantFilterType extends AbstractType
         if (in_array('project', $options['enabled_filters'])) {
             $builder->add('project', ProjectSelectType::class, [
                 'required' => false,
-
             ]);
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
@@ -131,18 +98,14 @@ class KlantFilterType extends AbstractType
                 'laatsteVerslagLocatie',
                 'laatsteVerslagDatum',
                 'huidigeMwStatus',
-                'gezin',
+                'isGezin',
                 'project',
-//                'verslag' => ['medewerker'],
                 'filter',
                 'download',
             ],
         ]);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getParent(): ?string
     {
         return FilterType::class;

--- a/src/MwBundle/Service/KlantDao.php
+++ b/src/MwBundle/Service/KlantDao.php
@@ -2,13 +2,12 @@
 
 namespace MwBundle\Service;
 
-use AppBundle\Doctrine\SqlExtractor;
 use AppBundle\Entity\Klant;
 use AppBundle\Filter\FilterInterface;
 use AppBundle\Service\AbstractDao;
-use MwBundle\Entity\Aanmelding;
-use MwBundle\Entity\Afsluiting;
-use PHPUnit\Framework\Error\Deprecated;
+use InloopBundle\Entity\Intake;
+use MwBundle\Entity\MwDossierStatus;
+use MwBundle\Entity\Verslag;
 
 class KlantDao extends AbstractDao implements KlantDaoInterface
 {
@@ -20,16 +19,12 @@ class KlantDao extends AbstractDao implements KlantDaoInterface
             'klant.achternaam',
             'klant.geboortedatum',
             'geslacht.volledig',
-            'medewerker.voornaam',
-            'maatschappelijkWerker.voornaam',
-            'verslag',
             'gebruikersruimte.naam',
-            'laatsteIntakeLocatie.naam',
-            'klant.intakedatum',
-            'datumLaatsteVerslag',
-            'aantalVerslagen',
+            'locatie.naam',
+            'project.naam',
+            'laatsteVerslag.datum',
         ],
-//        'wrap-queries' => true, // because of HAVING clause in filter
+        'wrap-queries' => true,
     ];
 
     protected $class = Klant::class;
@@ -38,110 +33,60 @@ class KlantDao extends AbstractDao implements KlantDaoInterface
 
     public function findAll($page = null, FilterInterface $filter = null)
     {
-//        @TODO: Query herschrijven zodat ie voldoen aan FULL GROUP BY. zie https://www.percona.com/blog/2019/05/13/solve-query-failures-regarding-only_full_group_by-sql-mode/
-
-        /**
-         * SELECT
-        # MAX(v0_.datum) AS datum_0,
-        l1_.naam AS naam_1,
-        #    COUNT(DISTINCT v0_.id) AS sclr_2,
-        k2_.MezzoID AS MezzoID_3, k2_.laatste_TBC_controle AS laatste_TBC_controle_4, k2_.first_intake_date AS first_intake_date_5, k2_.last_zrm AS last_zrm_6, k2_.overleden AS overleden_7, k2_.doorverwijzen_naar_amoc AS doorverwijzen_naar_amoc_8, k2_.corona_besmet_vanaf AS corona_besmet_vanaf_9, k2_.id AS id_10, k2_.deleted AS deleted_11, k2_.BSN AS BSN_12, k2_.geen_post AS geen_post_13, k2_.geen_email AS geen_email_14, k2_.opmerking AS opmerking_15, k2_.disabled AS disabled_16, k2_.roepnaam AS roepnaam_17, k2_.geboortedatum AS geboortedatum_18, k2_.voornaam AS voornaam_19, k2_.tussenvoegsel AS tussenvoegsel_20, k2_.achternaam AS achternaam_21, k2_.adres AS adres_22, k2_.postcode AS postcode_23, k2_.plaats AS plaats_24, k2_.email AS email_25, k2_.mobiel AS mobiel_26, k2_.telefoon AS telefoon_27, k2_.created AS created_28, k2_.modified AS modified_29,
-        i3_.id AS id_30, i3_.datum_intake AS datum_intake_31, i3_.amoc_toegang_tot AS amoc_toegang_tot_32, i3_.ondro_bong_toegang_van AS ondro_bong_toegang_van_33, i3_.overigen_toegang_van AS overigen_toegang_van_34, i3_.postadres AS postadres_35, i3_.postcode AS postcode_36, i3_.woonplaats AS woonplaats_37, i3_.telefoonnummer AS telefoonnummer_38, i3_.toegang_inloophuis AS toegang_inloophuis_39, i3_.mag_gebruiken AS mag_gebruiken_40, i3_.inkomen_overig AS inkomen_overig_41, i3_.legitimatie_nummer AS legitimatie_nummer_42, i3_.legitimatie_geldig_tot AS legitimatie_geldig_tot_43, i3_.verblijf_in_NL_sinds AS verblijf_in_NL_sinds_44, i3_.verblijf_in_amsterdam_sinds AS verblijf_in_amsterdam_sinds_45, i3_.opmerking_andere_instanties AS opmerking_andere_instanties_46, i3_.medische_achtergrond AS medische_achtergrond_47, i3_.verwachting_dienstaanbod AS verwachting_dienstaanbod_48, i3_.toekomstplannen AS toekomstplannen_49, i3_.indruk AS indruk_50, i3_.informele_zorg AS informele_zorg_51, i3_.dagbesteding AS dagbesteding_52, i3_.inloophuis AS inloophuis_53, i3_.hulpverlening AS hulpverlening_54, i3_.doelgroep AS doelgroep_55, i3_.verslaving_overig AS verslaving_overig_56, i3_.eerste_gebruik AS eerste_gebruik_57, i3_.geinformeerd_opslaan_gegevens AS geinformeerd_opslaan_gegevens_58, i3_.created AS created_59, i3_.modified AS modified_60, l4_.id AS id_61,
-        l4_.naam AS naam_62, l4_.nachtopvang AS nachtopvang_63, l4_.gebruikersruimte AS gebruikersruimte_64, l4_.maatschappelijkwerk AS maatschappelijkwerk_65, l4_.tbc_check AS tbc_check_66, l4_.wachtlijst AS wachtlijst_67, l4_.datum_van AS datum_van_68, l4_.datum_tot AS datum_tot_69, l4_.created AS created_70, l4_.modified AS modified_71,
-        k2_.werkgebied AS werkgebied_72, k2_.postcodegebied AS postcodegebied_73, k2_.first_intake_id AS first_intake_id_74, k2_.laste_intake_id AS laste_intake_id_75, k2_.huidigeStatus_id AS huidigeStatus_id_76, k2_.huidigeMwStatus_id AS huidigeMwStatus_id_77, k2_.mwBinnenViaOptieKlant_id AS mwBinnenViaOptieKlant_id_78, k2_.laatste_registratie_id AS laatste_registratie_id_79, k2_.merged_id AS merged_id_80, k2_.partner_id AS partner_id_81, k2_.maatschappelijkWerker_id AS maatschappelijkWerker_id_82, k2_.medewerker_id AS medewerker_id_83, k2_.land_id AS land_id_84, k2_.nationaliteit_id AS nationaliteit_id_85, k2_.geslacht_id AS geslacht_id_86,
-        i3_.klant_id AS klant_id_87, i3_.medewerker_id AS medewerker_id_88, i3_.locatie2_id AS locatie2_id_89, i3_.locatie1_id AS locatie1_id_90, i3_.locatie3_id AS locatie3_id_91, i3_.verblijfstatus_id AS verblijfstatus_id_92, i3_.legitimatie_id AS legitimatie_id_93, i3_.woonsituatie_id AS woonsituatie_id_94, i3_.infobaliedoelgroep_id AS infobaliedoelgroep_id_95, i3_.primaireProblematiek_id AS primaireProblematiek_id_96, i3_.primaireproblematieksfrequentie_id AS primaireproblematieksfrequentie_id_97, i3_.primaireproblematieksperiode_id AS primaireproblematieksperiode_id_98, i3_.verslavingsfrequentie_id AS verslavingsfrequentie_id_99, i3_.verslavingsperiode_id AS verslavingsperiode_id_100, i3_.zrm_id AS zrm_id_101
-        FROM klanten k2_
-        LEFT JOIN verslagen v0_ ON k2_.id = v0_.klant_id
-        LEFT JOIN medewerkers m5_ ON v0_.medewerker_id = m5_.id
-        LEFT JOIN medewerkers m6_ ON k2_.maatschappelijkWerker_id = m6_.id
-        LEFT JOIN verslagen v7_ ON k2_.id = v7_.klant_id AND (v0_.klant_id = v7_.klant_id AND (v0_.datum < v7_.datum OR (v0_.datum = v7_.datum AND v0_.id < v7_.id)))
-        LEFT JOIN geslachten g8_ ON k2_.geslacht_id = g8_.id
-        LEFT JOIN intakes i9_ ON k2_.id = i9_.klant_id
-        LEFT JOIN intakes i3_ ON k2_.laste_intake_id = i3_.id
-        LEFT JOIN locaties l10_ ON i3_.locatie2_id = l10_.id
-        LEFT JOIN locaties l1_ ON v0_.locatie_id = l1_.id
-        LEFT JOIN mw_dossier_statussen m11_ ON k2_.huidigeMwStatus_id = m11_.id AND m11_.class IN ('Aanmelding', 'Afsluiting')
-        LEFT JOIN locaties l4_ ON i3_.locatie1_id = l4_.id
-        WHERE (v7_.id IS NULL AND m11_.class IN ('Aanmelding') AND k2_.huidigeMwStatus_id IS NOT NULL) AND ((k2_.disabled IS NULL OR k2_.disabled = 0)) AND (k2_.deleted IS NULL)
-        # GROUP BY k2_.achternaam, k2_.id
-         */
-        /**
-         * @var KlantFilter $filter
-         */
-        $filter;
-
         $builder = $this->repository->createQueryBuilder($this->alias);
         $builder
-            ->select('klant, laatsteIntake, gebruikersruimte')
-            ->addSelect('verslag.datum AS datumLaatsteVerslag')
-            ->addSelect('locatie.naam AS laatsteVerslagLocatie')
-            ->addSelect('info.isGezin AS isGezin')
-            ->addSelect('COUNT(DISTINCT verslag.id) AS aantalVerslagen')
-
-            ;
-
-        $builder
-            ->leftJoin($this->alias.'.verslagen', 'verslag')
-            ->leftJoin('verslag.medewerker','medewerker')
-             ->leftJoin('klant.info','info');
-
-        $builder
+            ->select('klant, geslacht, maatschappelijkWerker, info')
+            ->leftJoin('klant.geslacht', 'geslacht')
             ->leftJoin('klant.maatschappelijkWerker','maatschappelijkWerker')
-            ->leftJoin($this->alias.'.verslagen','v2','WITH','verslag.klant = v2.klant AND (verslag.datum < v2.datum OR (verslag.datum = v2.datum AND verslag.id < v2.id))')
-            ->where('v2.id IS NULL')
-            ->leftJoin($this->alias.'.geslacht', 'geslacht')
-            ->leftJoin($this->alias.'.intakes', 'intake')
-            ->leftJoin($this->alias.'.laatsteIntake', 'laatsteIntake')
-            ->leftJoin('laatsteIntake.intakelocatie', 'laatsteIntakeLocatie')
-            ->leftJoin('verslag.locatie','locatie')
-            ->leftJoin($this->alias.'.huidigeMwStatus', 'huidigeMwStatus')
-            ->leftJoin('huidigeMwStatus.project','project')
+            ->leftJoin('klant.info', 'info')
+
+            // huidige MW status
+            ->addSelect('huidigeMwStatus')
+            ->join('klant.mwStatussen', 'huidigeMwStatus')
+            ->andWhere('huidigeMwStatus.id = FIRST(
+                SELECT s.id
+                FROM '.MwDossierStatus::class.' s
+                WHERE IDENTITY(s.klant) = klant.id
+                ORDER BY s.id DESC
+            )')
+            ->addSelect('project')
+            ->leftJoin('huidigeMwStatus.project', 'project')
+
+            // laatste verslag
+            ->addSelect('laatsteVerslag')
+            ->leftJoin('klant.verslagen', 'laatsteVerslag')
+            ->andWhere('laatsteVerslag.id IS NULL OR laatsteVerslag.id = FIRST(
+                SELECT v.id
+                FROM '.Verslag::class.' v
+                WHERE IDENTITY(v.klant) = klant.id
+                ORDER BY v.id DESC
+            )')
+            ->addSelect('locatie')
+            ->leftJoin('laatsteVerslag.locatie', 'locatie')
+
+            // laatste intake
+            ->addSelect('laatsteIntake')
+            ->leftJoin('klant.intakes', 'laatsteIntake')
+            ->andWhere('laatsteIntake.id IS NULL OR laatsteIntake.id = FIRST(
+                SELECT i.id
+                FROM '.Intake::class.' i
+                WHERE IDENTITY(i.klant) = klant.id
+                ORDER BY i.id DESC
+            )')
+            ->addSelect('gebruikersruimte')
             ->leftJoin('laatsteIntake.gebruikersruimte', 'gebruikersruimte')
-
-            ->groupBy('klant.achternaam, klant.id')
-            ;
-
+        ;
 
         if ($filter) {
             $filter->applyTo($builder);
         }
 
         if ($page) {
-            /**
-             * Vanwege de vele left joins in deze query is de total count niet te optimaliseren (door mij) onder de <900ms.
-             * Dat vind ik lang. Temeer omdat in veel gevallen die total count niet bijster interessant is.
-             *
-             * In de default configuratie van het filter wordt daarom de total count niet geteld. Dat scheelt een eerste snelle klik.
-             * Zodra je dan filtert gaat het sowieso sneller en wordt het juiste getal getoont.
-             *
-             */
-            $dql = $builder->getDQL();
-            $params = $builder->getParameters();
-//            $sql = $builder->getQuery()->getSQL();
-
-            $count = 11111;
-            if($filter->isDirty())
-            {
-                $builder->resetDQLPart("select");
-                $builder->select("klant.id");//select only one column for count query.
-
-                $countQuery = $builder->getQuery();
-                $fullSql = SqlExtractor::getFullSQL($countQuery);//including bound parameters.
-
-                $countSql = "SELECT COUNT(*) AS count FROM (".$fullSql.") tmp"; //wrap into subquery.
-                $countStmt = $this->entityManager->getConnection()->prepare($countSql);
-                $result = $countStmt->executeQuery();
-                $count = $result->fetchOne(0);
-            }
-            $query = $this->entityManager->createQuery($dql)->setHint('knp_paginator.count', $count);
-
-            $query->setParameters($params);
-            return $this->paginator->paginate($query, $page, $this->itemsPerPage,$this->paginationOptions);
+            return $this->paginator->paginate($builder, $page, $this->itemsPerPage, $this->paginationOptions);
         }
 
         return $builder->getQuery()->getResult();
     }
-
 
     /**
      * @param $startdatum

--- a/templates/mw/klanten/index.html.twig
+++ b/templates/mw/klanten/index.html.twig
@@ -89,44 +89,51 @@
                     {{ knp_pagination_sortable(pagination, 'Gebruikersruimte', 'gebruikersruimte.naam') }}
                 </th>
                 <th>
-                    Verslaglocatie
+                    {{ knp_pagination_sortable(pagination, 'Verslaglocatie', 'locatie.naam') }}
                 </th>
                 <th>
                     {{ knp_pagination_sortable(pagination, 'Project', 'project.naam') }}
                 </th>
                 <th>
-                    {{ knp_pagination_sortable(pagination, 'Maatschappelijk werker', 'maatschappelijkWerker.voornaam') }}
+                    Maatschappelijk werker
                 </th>
                 <th>
-                    {{ knp_pagination_sortable(pagination, 'Laatste verslag', 'datumLaatsteVerslag') }}
+                    {{ knp_pagination_sortable(pagination, 'Laatste verslag', 'laatsteVerslag.datum') }}
                 </th>
-                <th>Mw Dossierstatus</th>
+                <th>
+                    MW dossierstatus
+                </th>
                 <th></th>
             </tr>
         </thead>
         <tbody>
-            {% for item in pagination %}
-                {% set klant = item[0] %}
-                {% set rowColorClass = '' %}
-                {% set ttactive = "" %}
-                {% set tttext = "" %}
-                {% if(date(item.datumLaatsteVerslag) < date("-6 months")) %}
-                    {%  set rowColorClass = 'danger' %}
-                    {% set ttactive = "tooltip" %}
-                    {% set tttext = "Laatste verslag meer dan 6 maanden geleden." %}
-                {% elseif(date(item.datumLaatsteVerslag) < date("-3 months")) %}
-                    {% set rowColorClass = 'warning' %}
-                    {% set ttactive = "tooltip" %}
-                    {% set tttext = "Laatste verslag meer dan 3 maanden geleden." %}
-                {% endif %}
-                {% if klant.briefadres is not null and date(klant.briefadres) < date("+6 weeks")  %}
-                    {% set rowColorClass = 'danger' %}
-                    {% set ttactive = "tooltip" %}
-                    {% set tttext = tttext ~ " Briefadres loopt binnenkort af." %}
+            {% for klant in pagination %}
+                {% set huidigeMwStatus = klant.mwStatussen[0] %}
+                {% set laatsteIntake = klant.intakes|length ? klant.intakes[0] %}
+                {% set laatsteVerslag = klant.verslagen|length ? klant.verslagen[0] %}
+
+                {% set class = '' %}
+                {% set messages = [] %}
+
+                {% if laatsteVerslag %}
+                    {% if date(laatsteVerslag.datum) < date("-6 months") %}
+                        {% set class = 'danger' %}
+                        {% set messages = messages|merge(["Laatste verslag meer dan 6 maanden geleden."]) %}
+                    {% elseif date(laatsteVerslag.datum) < date("-3 months") %}
+                        {% set class = 'warning' %}
+                        {% set messages = messages|merge(["Laatste verslag meer dan 3 maanden geleden."]) %}
+                    {% endif %}
                 {% endif %}
 
-                <tr href="#" data-toggle="{{ ttactive }}" title="{{ tttext }}" data-container="body"
-                        class="{{ rowColorClass }}" data-href="{{ path(route_base~'view', {id: klant.id}) }}">
+                {% if klant.briefadres %}
+                    {% if date(klant.briefadres) < date("+6 years") %}
+                        {% set class = 'danger' %}
+                        {% set messages = messages|merge(["Briefadres loopt binnenkort af."]) %}
+                    {% endif %}
+                {% endif %}
+
+                <tr href="#" {% if messages|length %}data-toggle="tooltip" data-container="body" title="{{ messages|join(" ") }}"{% endif %}
+                    class="{{ class }}" data-href="{{ path(route_base~'view', {id: klant.id}) }}">
                     <td>
                         {{ klant.id }}
                     </td>
@@ -140,42 +147,42 @@
                         {{ klant.geslacht }}
                     </td>
                     <td>
-                        {{ klant.laatsteIntake ? klant.laatsteIntake.gebruikersruimte }}
+                        {{ laatsteIntake ? laatsteIntake.gebruikersruimte }}
                     </td>
                     <td>
-                        {{ item.laatsteVerslagLocatie }}
+                        {{ laatsteVerslag ? laatsteVerslag.locatie }}
                     </td>
                     <td>
-                        {{ klant.huidigeMwStatus? klant.huidigeMwStatus.project }}
+                        {{ huidigeMwStatus.project }}
                     </td>
                     <td>
                         <ul>
-                            {% if klant.maatschappelijkWerker is defined and klant.maatschappelijkWerker is not null %}
-                                <li>{{ klant.maatschappelijkWerker }}</li>
-                            {% else %}
-                                {% set verslagMedewerker = null %}
-                                {% set i = 0 %}
-
-                                {% for verslag in klant.verslagen %}
-                                    {% if i < 3 and verslag.medewerker != verslagMedewerker %}
-                                        <li>{{ verslag.medewerker }}</li>
-                                        {% set i = i+1 %}
-                                    {% elseif loop.index == 3 %}
-                                        <li>(...({{ loop.length - 3 }}))</li>
-                                    {% endif %}
-                                    {% set verslagMedewerker = verslag.medewerker %}
-                                {% endfor %}
+                            {% set medewerkers = [huidigeMwStatus.medewerker] %}
+                            {% if klant.maatschappelijkWerker %}
+                                {% if klant.maatschappelijkWerker not in medewerkers %}
+                                    {% set medewerkers = medewerkers|merge([klant.maatschappelijkWerker]) %}
+                                {% endif %}
                             {% endif %}
+                            {% if laatsteVerslag %}
+                                {% if laatsteVerslag.medewerker not in medewerkers %}
+                                    {% set medewerkers = medewerkers|merge([laatsteVerslag.medewerker]) %}
+                                {% endif %}
+                            {% endif %}
+                            {% for medewerker in medewerkers %}
+                                <li>{{ medewerker }}</li>
+                            {% endfor %}
                         </ul>
                     </td>
                     <td>
-                        {{ item.datumLaatsteVerslag|if_date('d-m-Y') }}
+                        {{ laatsteVerslag ? laatsteVerslag.datum|date('d-m-Y') }}
                     </td>
                     <td>
-                        {{ klant.huidigeMwStatus }}
+                        {{ huidigeMwStatus }}
                     </td>
                     <td>
-                        {{ html.link('Verslag toevoegen', path('mw_verslagen_add', {klant: klant.id}), 'add') }}
+                        {% if instanceof(huidigeMwStatus, 'MwBundle\\Entity\\Aanmelding') %}
+                            {{ html.link('Verslag toevoegen', path('mw_verslagen_add', {klant: klant.id}), 'add') }}
+                        {% endif %}
                     </td>
                 </tr>
             {% endfor %}


### PR DESCRIPTION
@jtborger Wil je hier eens naar kijken? In navolging van onze discussie op Slack, heb ik een custom DQL-functie `FIRST` toegevoegd. Die kan gebruikt worden om bv. de huidige MW status, het laatste verslag en de laatste intake te joinen d.m.v. sub-queries met een `ORDER BY`. Het werkt zo, inclusief sorteren en filteren, maar het is niet erg snel. Ik vraag me dus af of die de juiste oplossingsrichting is. Simpelweg bijhouden van de huidige MW status, het laatste verslag en de laatste intake zou het geheel een stuk sneller maken, met als offer wat toegenomen complexiteit. Daarvoor hebben we verschillende opties, zoals op Slack besproken. Kortom, ik heb hier wat input nodig.

Zou het ook nog idee zijn om het MW-scherm op te splitsen in meerdere kleinere overzichten? Ik weet niet hoe dit in praktijk gebruikt wordt, maar bv per project/locatie/medewerker, ik noem maar wat...