### PR TITLE
Closes #1781 Bij nieuwe gebruikers die nooit zijn ingelogd kon je ze …

### DIFF
--- a/src/AppBundle/Entity/Medewerker.php
+++ b/src/AppBundle/Entity/Medewerker.php
@@ -254,6 +254,12 @@ class Medewerker implements UserInterface, PasswordAuthenticatedUserInterface, E
      */
     public function getRoles()
     {
+        //extra check if roles is not empty; cause it can be an array or json (string) check on both.
+        //defaults to [] but can be overriden somehow. ?
+        if(!is_array($this->roles)
+            && (!is_string($this->roles) && strlen($this->roles) < 1)
+        ) $this->roles = [];
+
         return $this->roles;
     }
 


### PR DESCRIPTION
…niet op actief zetten omdat $roles leeg was, en dat mocht niet.