### PR TITLE
Set default for 'bsn_required' in KlantType form

### DIFF
--- a/src/AppBundle/Form/KlantType.php
+++ b/src/AppBundle/Form/KlantType.php
@@ -78,6 +78,7 @@ class KlantType extends AbstractType
         $resolver->setDefaults([
             'data_class' => Klant::class,
             'data' => null,
+            'bsn_required'=>false,
         ]);
     }
 


### PR DESCRIPTION
Added a default value for 'bsn_required' to false in the KlantType form configuration. This ensures the 'bsn_required' field is not mandatory by default when constructing the form.