### PR TITLE
Fixes #1854 heropenenAction method to reset einddatum

### DIFF
--- a/src/HsBundle/Controller/KlussenController.php
+++ b/src/HsBundle/Controller/KlussenController.php
@@ -76,9 +76,9 @@ class KlussenController extends AbstractChildController
     public function heropenenAction(Request $request, $id)
     {
         $entity = $this->dao->find($id);
-        $entity->setAnnuleringsdatum(null);
+        $entity->setEinddatum(null);
         $this->dao->update($entity);
-        $this->addFlash('success', ucfirst($this->entityName).' is opgeslagen.');
+        $this->addFlash('success', ucfirst($this->entityName).' is heropend.');
 
         return $this->redirectToView($entity);
     }


### PR DESCRIPTION
Previously, the method reset the annuleringsdatum instead of the einddatum when reopening an entity. Also, updated the success flash message to correctly indicate that the entity has been reopened.