### PR TITLE
Fixed Vrijwilliger afsluiting in Maatschappelijk werk

### DIFF
--- a/src/MwBundle/Entity/Vrijwilliger.php
+++ b/src/MwBundle/Entity/Vrijwilliger.php
@@ -205,14 +205,24 @@ class Vrijwilliger implements MemoSubjectInterface, DocumentSubjectInterface
 
     public function getAfsluitredenVrijwilliger()
     {
+        return $this->getAfsluitreden();
+    }
+
+    public function getAfsluitreden()
+    {
         return $this->afsluitreden;
     }
 
-    public function setAfsluitredenVrijwilliger(?AfsluitredenVrijwilliger $afsluitreden)
+    public function setAfsluitreden(?AfsluitredenVrijwilliger $afsluitreden)
     {
         $this->afsluitreden = $afsluitreden;
 
         return $this;
+    }
+
+    public function setAfsluitredenVrijwilliger(?AfsluitredenVrijwilliger $afsluitreden)
+    {
+        return $this->setAfsluitreden($afsluitreden);
     }
 
     public function getBinnenVia()


### PR DESCRIPTION
Fixed #1871 Ik heb gemerkt dat de functie die we nodig hebben voor Afsluting in de Vrijwilliger-klasse niet correct is gedefinieerd. Ik heb ze aangesproken met getAfsluitreden en setAfsluitreden. Nu kan ik een vrijwillig goed afsluiten.

setExclusionredenVrijwilliger($afsluiten)
getExitReasonsVrijwilliger()