### PR TITLE
#1858 de antaal van koppelingen per afsluitredenen in Rapportage heef…

### DIFF
--- a/src/TwBundle/Service/HuurovereenkomstDao.php
+++ b/src/TwBundle/Service/HuurovereenkomstDao.php
@@ -122,8 +122,8 @@ class HuurovereenkomstDao extends AbstractDao implements HuurovereenkomstDaoInte
         $builder = $this->getCountBuilder($startdate, $enddate)
             ->addSelect('afsluitreden.naam AS groep')
             ->innerJoin("{$this->alias}.afsluiting", 'afsluitreden')
-            ->andWhere("{$this->alias}.startdatum <= :end")
-            ->andWhere("{$this->alias}.einddatum >= :start")
+            ->andWhere("{$this->alias}.startdatum >= :start")
+            ->andWhere("{$this->alias}.afsluitdatum <= :end")
             ->groupBy('groep')
         ;
 


### PR DESCRIPTION
Fixed #1858 

Ik realiseerde me dat in het gedeelte Koppelingen per afsluitreden in Rapportages, de berekening niet correct werd uitgevoerd.

De oorzaak hiervan was dat de datumbereik van start tot afsluiting moest worden gecontroleerd.
Daarnaast waren de SQL-voorwaarden niet correct ingesteld met betrekking tot de datums.

Ik heb deze problemen opgelost, en nu wordt het aantal correct weergegeven in het rapport.
