### PR TITLE
#1836 Fixed the alert message  if toestemmingsformulier does not exist, in MW Klanten page.

### DIFF
--- a/templates/mw/klanten/view.html.twig
+++ b/templates/mw/klanten/view.html.twig
@@ -33,6 +33,13 @@
             om een nieuwe ZRM toe te voegen.
         </p>
     {% endif %}
+    {% if not entity.toestemmingsformulier %}
+        <p class="text-danger">
+            LET OP: geen toestemmingsformulier aanwezig. Klik
+            {{ html.link('hier', path('app_documenten_add', {klant: entity.id, type: 'toestemming'})) }}
+            om een Toestemmingsformulier toe te voegen.
+        </p>
+    {% endif %}
 {% endblock %}
 
 {% block content_left %}


### PR DESCRIPTION
#1836 Ik heb een melding toegevogt in klanten dossier als toestemmingsformulier ontbreekt.

`LET OP: geen toestemmingsformulier aanwezig. Klik hier om een Toestemmingsformulier toe te voegen.`