### PR TITLE
Fixed the list of future trainigs in tab training in oek group

### DIFF
--- a/src/OekBundle/Entity/Groep.php
+++ b/src/OekBundle/Entity/Groep.php
@@ -138,8 +138,8 @@ class Groep
     {
         $criteria = Criteria::create()
             ->where(Criteria::expr()->gte('einddatum', new \DateTime()))
+            ->orWhere(Criteria::expr()->gte('startdatum', new \DateTime()))
         ;
-
         return $this->trainingen->matching($criteria);
     }
 


### PR DESCRIPTION
#1380 
ik zie in source code de training tabblad moet de trainingen van toekomst laten te zien, dat is logisch dat verschilende records heeft met training overzicht. maar ik heb een bug daar gefixd om toekomste training te rekenen.