### PR TITLE
#1878 Split Slapers with two tabs by type in Villa page

### DIFF
--- a/src/VillaBundle/Controller/SlapersController.php
+++ b/src/VillaBundle/Controller/SlapersController.php
@@ -139,4 +139,17 @@ class SlapersController extends AbstractController implements DossierStatusContr
             throw new UserException("Kan geen dossier bewerken dat afgesloten is.");
         }
     }
+
+    /**
+     * @Route("/type/{type?}")
+     * @Template("villa/slapers/index.html.twig")
+     */
+    public function indexTypeAction(Request $request){
+        $type = $request->get('type', 1);
+        $filters = $request->query->get('slaper_filter', []); 
+        $filters['type'] = $type; 
+        $request->query->set('slaper_filter', $filters); 
+
+        return parent::indexAction($request);
+    }
 }

--- a/templates/navigation.html.twig
+++ b/templates/navigation.html.twig
@@ -58,7 +58,7 @@
     {{ html.navLink('Uit het Krijt', path('uhk_index'), isActiveRoute('uhk_')) }}
 {% endif %}
 {% if is_granted('ROLE_VILLA') %}
-    {{ html.navLink('Villa', path('villa_slapers_index'), isActiveRoute('villa_')) }}
+    {{ html.navLink('Villa', path('villa_slapers_indextype', { 'type' : 1 } ), isActiveRoute('villa_')) }}
 {% endif %}
 {% if is_granted('ROLE_ADMIN') %}
     <li role="presentation" class="dropdown {{ isActivePath('inloop/admin') ? 'active' }}">

--- a/templates/villa/subnavigation.html.twig
+++ b/templates/villa/subnavigation.html.twig
@@ -5,8 +5,9 @@
     <li class="active">{{ title }}</li>
 </ol>
 <ul class="nav nav-tabs">
-    {{ html.navLink('Slapers', path('villa_slapers_index'), isActiveRoute('villa_slapers_')) }}
     {{ html.navLink('Vrijwilligers', path('villa_vrijwilligers_index'), isActiveRoute('villa_vrijwilligers_')) }}
+    {{ html.navLink('Respijtzorg', path('villa_slapers_indextype', { 'type': 1 }), isActiveRoute(['villa_slapers_indextype','1'], 'AND')) }}
+    {{ html.navLink('Logeeropvang', path('villa_slapers_indextype',{ 'type': 2 }), isActiveRoute(['villa_slapers_indextype','2'], 'AND')) }}
     {{ html.navLink('Rapportages', path('villa_rapportages_index'), isActiveRoute('villa_rapportages_')) }}
     <li role="presentation" class="dropdown {{ isActivePath('villa/admin') ? 'active' }}">
         <a class="dropdown-toggle active" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">


### PR DESCRIPTION
#1878 Ik heb Slapers via SlapersController opgesplitst in twee tabbladen: Respijtzorg en Logeeropvang.

We hebben nu twee afzonderlijke tabbladen met vergelijkbare functionaliteit voor verschillende typen, wat naar mijn mening op dit moment voldoende zou moeten zijn.

Ik heb de oude template gebruikt, en die is voor beide hetzelfde. Laat het me weten als het nodig is om ze een andere uitstraling te geven, dan zal ik ze in twee verschillende templates met aparte titels plaatsen.

