### PR TITLE
#1872 Fixed verhuurder name in export file for TW

### DIFF
--- a/config/services/tw/exports.yaml
+++ b/config/services/tw/exports.yaml
@@ -41,9 +41,7 @@ services:
                 Aanmelddatum: { expression: 'entity.getAanmelddatum()', type: 'date' }
                 Afsluitdatum: { expression: 'entity.getAfsluitdatum()', type: 'date' }
                 Geslacht: { expression: 'entity.getAppKlant().getGeslacht()' }
-                Voornaam: { expression: 'entity.getAppKlant().getVoornaam()' }
-                Tussenvoegsel: { expression: 'entity.getAppKlant().getTussenvoegsel()' }
-                Achternaam: { expression: 'entity.getAppKlant().getAchternaam()' }
+                Verhuurder: { expression: 'entity.getAppKlant()' }
                 Geboortedatum: { expression: 'entity.getAppKlant().getGeboortedatum()', type: 'date' }
                 E-mail: { expression: 'entity.getAppKlant().getEmail()' }
                 Adres: { expression: 'entity.getAppKlant().getAdres()' }


### PR DESCRIPTION
ik heb de verhuurder naam van export gefixed(van 3 kalomnen naar een heelnaam).

![image](https://github.com/user-attachments/assets/e00a1174-3141-41f5-a277-e9b0860756bd)
