### PR TITLE
#1874 auto traject sluiten 2

### DIFF
--- a/src/DagbestedingBundle/Controller/DeelnemersController.php
+++ b/src/DagbestedingBundle/Controller/DeelnemersController.php
@@ -162,9 +162,10 @@ class DeelnemersController extends AbstractController
                 $countTrajecten = count($trajecten);
 
                 foreach ($trajecten as $traject) {
-                    $afs = $form->get('afsluiting_trajecten')->getData();
-                    $traject->setAfsluiting($afs);
-                    $traject->setAfsluitdatum($entity->getAfsluitdatum());
+                    if($afs = $form->get('afsluiting_trajecten')->getData()) {
+                        $traject->setAfsluiting($afs);
+                        $traject->setAfsluitdatum($entity->getAfsluitdatum());
+                    }
                 }
                 
                 $this->dao->update($entity);

--- a/src/DagbestedingBundle/Controller/DeelnemersController.php
+++ b/src/DagbestedingBundle/Controller/DeelnemersController.php
@@ -9,6 +9,8 @@ use AppBundle\Export\GenericExport;
 use AppBundle\Form\KlantFilterType;
 use AppBundle\Service\KlantDaoInterface;
 use DagbestedingBundle\Entity\Deelnemer;
+use DagbestedingBundle\Entity\Traject;
+use DagbestedingBundle\Entity\Trajectafsluiting;
 use DagbestedingBundle\Form\DeelnemerCloseType;
 use DagbestedingBundle\Form\DeelnemerFilterType;
 use DagbestedingBundle\Form\DeelnemerReopenType;
@@ -156,8 +158,19 @@ class DeelnemersController extends AbstractController
 
         if ($form->isSubmitted() && $form->isValid()) {
             try {
-                $this->dao->update($entity);
+                $trajecten = $entity->getOpenTrajecten();
+                $countTrajecten = count($trajecten);
 
+                foreach ($trajecten as $traject) {
+                    $afs = $form->get('afsluiting_trajecten')->getData();
+                    $traject->setAfsluiting($afs);
+                    $traject->setAfsluitdatum($entity->getAfsluitdatum());
+                }
+                
+                $this->dao->update($entity);
+                if($countTrajecten > 0) {
+                    $this->addFlash('success', $countTrajecten.' trajecten zijn afgesloten.');
+                }
                 $this->addFlash('success', $this->entityName.' is afgesloten.');
             } catch (UserException $e) {
                 //                $this->logger->error($e->getMessage(), ['exception' => $e]);

--- a/src/DagbestedingBundle/Entity/Deelnemer.php
+++ b/src/DagbestedingBundle/Entity/Deelnemer.php
@@ -298,6 +298,22 @@ class Deelnemer
         return $this->trajecten;
     }
 
+    public function getOpenTrajecten()
+    {
+        $result = [];
+        foreach($this->getTrajecten() as $traject) {
+            if(null == $traject->getAfsluiting()){
+                $result[] = $traject;
+            }
+        }
+        return $result;
+    }
+
+    public function hasOpenTrijecten(): bool 
+    {
+        return 0 < count($this->getOpenTrajecten());
+    }
+
     public function addTraject(Traject $traject)
     {
         $this->trajecten[] = $traject;

--- a/src/DagbestedingBundle/Form/DeelnemerCloseType.php
+++ b/src/DagbestedingBundle/Form/DeelnemerCloseType.php
@@ -6,6 +6,8 @@ use AppBundle\Form\AppDateType;
 use AppBundle\Form\BaseType;
 use DagbestedingBundle\Entity\Deelnemer;
 use DagbestedingBundle\Entity\Deelnemerafsluiting;
+use DagbestedingBundle\Entity\Trajectafsluiting;
+use IzBundle\Form\AfsluitingSelectType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -23,8 +25,20 @@ class DeelnemerCloseType extends AbstractType
                 'required' => true,
                 'placeholder' => 'Selecteer een item',
             ])
-            ->add('submit', SubmitType::class, ['label' => 'Afsluiten'])
         ;
+        /// check if there are open trajecten
+        if ($builder->getData()->hasOpenTrijecten()) {
+            /// This is a custom field for afsluitings of trajects of this deelnemer.
+            $builder->add('afsluiting_trajecten', AfsluitingSelectType::class, [
+                'class' => Trajectafsluiting::class,
+                'label' => 'Reden afsluiting van trajecten',
+                'required' => true,
+                'placeholder' => 'Selecteer een item',
+                'mapped' => false,
+            ]);
+        }
+
+        $builder->add('submit', SubmitType::class, ['label' => 'Afsluiten']);
     }
 
     public function configureOptions(OptionsResolver $resolver)


### PR DESCRIPTION
#1874 
Hi @jtborger 

Aangezien Trajecten een reden nodig hebben om gesloten te worden, heb ik een custom field toegevoegd aan het formulier DeelnemerAfsluiting.

Dit veld wordt dynamisch gecontroleerd: als de Deelnemer bij het afsluiten Trajecten heeft die ook gesloten moeten worden en een reden vereisen, verschijnt dit veld zodat de Trajecten ermee gesloten kunnen worden. Anders wordt het veld niet weergegeven.

In de beschrijving van dit probleem stond dat wanneer we een Traject willen sluiten, er een mogelijkheid moet zijn om de gebruiker te vragen of ze ook de Deelnemer willen sluiten.

Ik zag dat deze vraag momenteel al als een checkbox bestaat en goed werkt, dus ik heb hier niets nieuws voor ontwikkeld.

![image](https://github.com/user-attachments/assets/b8401e60-2834-4089-ad42-722d2dad4499)
