### PR TITLE
Fixed #1757 fixed nullable inkomen field for dossier of klanten in Ti…

### DIFF
--- a/src/TwBundle/Entity/Deelnemer.php
+++ b/src/TwBundle/Entity/Deelnemer.php
@@ -453,7 +453,7 @@ abstract class Deelnemer implements KlantRelationInterface
         return $this->inkomen;
     }
 
-    public function setInkomen(Inkomen $inkomen): Deelnemer
+    public function setInkomen(?Inkomen $inkomen): Deelnemer
     {
         $this->inkomen = $inkomen;
 


### PR DESCRIPTION
@jtborger 

Ik vond het probleem bij het bewerken van een klant. De bug had te maken met `setInkomen`, die null-waarden moest toestaan. Dit is opgelost met een kleine vraagteken (`?`).