### PR TITLE
fixes #1859 avp veld voor huurovereenkomst

### DIFF
--- a/fixtures/tw.yaml
+++ b/fixtures/tw.yaml
@@ -80,6 +80,11 @@ TwBundle\Entity\Klant:
         werk: '@tw_werk_*'
         duurthuisloos: '@tw_duurthuisloos_*'
         intakestatus: '@tw_intakestatus_*'
+    
+    tw_klant_{1..2}:
+        appKlant: '@klant_<current()>'
+        projecten: ['@tw_project_odp', '@tw_project_tod']
+        medewerker: '@medewerker_<current()>'
 
 TwBundle\Entity\Verhuurder:
     tw_verhuurder_{1..10}:
@@ -113,3 +118,8 @@ TwBundle\Entity\Huurovereenkomst:
 TwBundle\Entity\Regio:
     tw_binding_regio_{1..5}:
         naam: 'REGIO <current()>'
+
+TwBundle\Entity\VormVanOvereenkomst:
+    tw_vormvanovereenkomst_{1..5}:
+        label: 'Vorm van overeenkomst <current()>'
+

--- a/migrations/2025/Version20250325124937.php
+++ b/migrations/2025/Version20250325124937.php
@@ -20,7 +20,7 @@ final class Version20250325124937 extends AbstractMigration
     public function up(Schema $schema): void
     {
         // this up() migration is auto-generated, please modify it to your needs
-        $this->addSql('ALTER TABLE tw_huurovereenkomsten ADD huurderAVP TINYINT(1) NOT NULL');
+        $this->addSql('ALTER TABLE tw_huurovereenkomsten ADD huurderAVP TINYINT(1) DEFAULT NULL');
     }
 
     public function down(Schema $schema): void

--- a/migrations/2025/Version20250325124937.php
+++ b/migrations/2025/Version20250325124937.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250325124937 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE tw_huurovereenkomsten ADD huurderAVP TINYINT(1) NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE tw_huurovereenkomsten DROP huurderAVP');
+    }
+}

--- a/src/TwBundle/Entity/Huurovereenkomst.php
+++ b/src/TwBundle/Entity/Huurovereenkomst.php
@@ -188,6 +188,14 @@ class Huurovereenkomst
      */
     protected $modified;
 
+
+    /**
+     * @var bool
+     * @ORM\Column(type="boolean")
+     * @Gedmo\Versioned
+     */
+    protected $huurderAVP;
+
     public function __construct()
     {
         $this->startdatum = new \DateTime();
@@ -430,5 +438,15 @@ class Huurovereenkomst
     public function setVormVanOvereenkomst(?VormVanOvereenkomst $vormVanOvereenkomst): void
     {
         $this->vormVanOvereenkomst = $vormVanOvereenkomst;
+    }
+
+    public function getHuurderAVP(): ?bool
+    {
+        return $this->huurderAVP;
+    }
+
+    public function setHuurderAVP(?bool $huurderAVP): void
+    {
+        $this->huurderAVP = $huurderAVP;
     }
 }

--- a/src/TwBundle/Form/HuurovereenkomstType.php
+++ b/src/TwBundle/Form/HuurovereenkomstType.php
@@ -48,6 +48,10 @@ class HuurovereenkomstType extends AbstractType
                 'required' => false,
             ])
             ->add('huurovereenkomstType')
+            ->add('huurderAVP', null, [
+                    'required' => false, 
+                    'label' => 'de huurder heeft een AVP (aansprakelijkheidsverzekering Particulieren)'
+            ])
 
             ->add('submit', SubmitType::class, ['label' => 'Opslaan'])
         ;

--- a/templates/tw/huurovereenkomsten/view.html.twig
+++ b/templates/tw/huurovereenkomsten/view.html.twig
@@ -56,7 +56,7 @@
             {% endif %}
         </dd>
         <dt>Opzegbrief verstuurd</dt>
-        <dd>{{ entity.opzegbriefVerstuurd ? 'Ja' : 'Nee' }}</dd>
+        <dd>{{ entity.opzegbriefVerstuurd | ja_nee }}</dd>
         <dt>Einddatum</dt>
         <dd>{{ entity.einddatum ? entity.einddatum|date('d-m-Y') }}</dd>
         <dt>Vorm van overeenkomst</dt>
@@ -67,6 +67,8 @@
         <dd>{{ entity.afsluitdatum ? entity.afsluitdatum|date('d-m-Y') }}</dd>
         <dt>Reden afsluiting</dt>
         <dd>{{ entity.afsluiting ? entity.afsluiting }}</dd>
+        <dt>heeft de huurder<br> een AVP?</dt>
+        <dd>{{ entity.huurderAVP | ja_nee }}</dd>
     </dl>
 {% endblock %}
 


### PR DESCRIPTION
Hi @jtborger 

Ik heb een nieuw veld toegevoegd aan de tabel tw_huurovereenkomsten. Vervolgens wordt in het formulier voor het aanmaken van een koppeling gevraagd of de huurder een AVP heeft of niet.

Ik denk dat we dit veld ook aan de tabel tw_huurverzoek hadden kunnen toevoegen, maar omdat het meer betrekking heeft op de huurovereenkomst, heb ik ervoor gekozen om het in het Koppeling-formulier op te nemen.

Overige wijzigingen:

- Aanpassing in de fixtures
- Migration

> Wat er moet gebeuren: er moet een klant (huurder) worden aangemaakt. Dit zit nog niet in fixtures, dus fijn als je dit direct wilt doen.
Er moeten huurverzoeken (vanuit de klant) en huuraanbieidngne worden gemaakt (vanuit de verhuurder)
Van daaruit ontstaat een koppeling ==> dat is de huurovereenkomst.
Op die koppeling moet dus een veld komen of de huurder (klant) een AVP heeft. Dat is idd een extra veld. Het is mss al goed om die te registreren in het huurverzoek. Je moet even kijken (ik heb dat nu niet helder) welke dingen in het huurverzoek al uitgevraagd worden, en welke dingen bij de totstandkoming van de koppeling.