### PR TITLE
Fixes #1983 Klanten blauw kleuren in het Klanten overzicht van Inloop…

### DIFF
--- a/templates/inloop/klanten/index.html.twig
+++ b/templates/inloop/klanten/index.html.twig
@@ -90,7 +90,20 @@
         </thead>
         <tbody>
             {% for klant in pagination %}
-                <tr data-href="{{ path('inloop_klanten_view', {id: klant.id}) }}">
+                {% set class = "" %}
+                {% set ttactive = "" %}
+                {% set tttext = "" %}
+
+                {% if klant.eersteIntake.beschikkingWachtlijstbegeleiding %}
+                    {% set class = "info" %}
+                    {% set ttactive = "tooltip" %}
+                    {% set tttext = "Klant heeft recht op wachtlijstbegeleiding." %}
+                {% endif %}
+                <tr data-href="{{ path('inloop_klanten_view', {id: klant.id}) }}" 
+                    class="{{ class }}"
+                    data-toggle="{{ ttactive }}"
+                    title="{{ tttext }}"
+                >
                     <td>
                         {{ klant.id }}
                     </td>


### PR DESCRIPTION
Hi @jtborger Ik heb de kleur blauw als achtergrond gebruikt voor gebruikers die al actieve wachtlijstbegeleiding hebben.









Ask ChatGPT
